### PR TITLE
Added new WCAG version 2.2

### DIFF
--- a/translations/AT-WCAG22-NL-20240129/index.html
+++ b/translations/AT-WCAG22-NL-20240129/index.html
@@ -1,0 +1,9311 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="nl" xml:lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="generator" content="ReSpec 24.35.2" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <style>
+      /* --- ISSUES/NOTES --- */
+      .issue-label {
+        text-transform: initial;
+      }
+
+      .warning > p:first-child {
+        margin-top: 0;
+      }
+      .warning {
+        padding: 0.5em;
+        border-left-width: 0.5em;
+        border-left-style: solid;
+      }
+      span.warning {
+        padding: 0.1em 0.5em 0.15em;
+      }
+
+      .issue.closed span.issue-number {
+        text-decoration: line-through;
+      }
+
+      .warning {
+        border-color: #f11;
+        border-width: 0.2em;
+        border-style: solid;
+        background: #fbe9e9;
+      }
+
+      .warning-title:before {
+        content: '⚠'; /*U+26A0 WARNING SIGN*/
+        font-size: 1.3em;
+        float: left;
+        padding-right: 0.3em;
+        margin-top: -0.3em;
+      }
+
+      li.task-list-item {
+        list-style: none;
+      }
+
+      input.task-list-item-checkbox {
+        margin: 0 0.35em 0.25em -1.6em;
+        vertical-align: middle;
+      }
+
+      .issue a.respec-gh-label {
+        padding: 5px;
+        margin: 0 2px 0 2px;
+        font-size: 10px;
+        text-transform: none;
+        text-decoration: none;
+        font-weight: bold;
+        border-radius: 4px;
+        position: relative;
+        bottom: 2px;
+        border: none;
+      }
+
+      .issue a.respec-label-dark {
+        color: #fff;
+        background-color: #000;
+      }
+
+      .issue a.respec-label-light {
+        color: #000;
+        background-color: #fff;
+      }
+    </style>
+
+    <title>Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.2</title>
+    <style id="respec-mainstyle">
+      /*****************************************************************
+       * ReSpec 3 CSS
+       * Robin Berjon - http://berjon.com/
+       *****************************************************************/
+
+      @keyframes pop {
+        0% {
+          transform: scale(1, 1);
+        }
+        25% {
+          transform: scale(1.25, 1.25);
+          opacity: 0.75;
+        }
+        100% {
+          transform: scale(1, 1);
+        }
+      }
+
+      /* Override code highlighter background */
+      .hljs {
+        background: transparent !important;
+      }
+
+      /* --- INLINES --- */
+      h1 abbr,
+      h2 abbr,
+      h3 abbr,
+      h4 abbr,
+      h5 abbr,
+      h6 abbr,
+      a abbr {
+        border: none;
+      }
+
+      dfn {
+        font-weight: bold;
+      }
+
+      a.internalDFN {
+        color: inherit;
+        border-bottom: 1px solid #99c;
+        text-decoration: none;
+      }
+
+      a.externalDFN {
+        color: inherit;
+        border-bottom: 1px dotted #ccc;
+        text-decoration: none;
+      }
+
+      a.bibref {
+        text-decoration: none;
+      }
+
+      .respec-offending-element:target {
+        animation: pop 0.25s ease-in-out 0s 1;
+      }
+
+      .respec-offending-element,
+      a[href].respec-offending-element {
+        text-decoration: red wavy underline;
+      }
+      @supports not (text-decoration: red wavy underline) {
+        .respec-offending-element:not(pre) {
+          display: inline-block;
+        }
+        .respec-offending-element {
+          /* Red squiggly line */
+          background: url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=)
+            bottom repeat-x;
+        }
+      }
+
+      #references :target {
+        background: #eaf3ff;
+        animation: pop 0.4s ease-in-out 0s 1;
+      }
+
+      cite .bibref {
+        font-style: normal;
+      }
+
+      code {
+        color: #c83500;
+      }
+
+      th code {
+        color: inherit;
+      }
+
+      a[href].orcid {
+        padding-left: 4px;
+        padding-right: 4px;
+      }
+
+      a[href].orcid > svg {
+        margin-bottom: -2px;
+      }
+
+      /* --- TOC --- */
+
+      .toc a,
+      .tof a {
+        text-decoration: none;
+      }
+
+      a .secno,
+      a .figno {
+        color: #000;
+      }
+
+      ul.tof,
+      ol.tof {
+        list-style: none outside none;
+      }
+
+      .caption {
+        margin-top: 0.5em;
+        font-style: italic;
+      }
+
+      /* --- TABLE --- */
+
+      table.simple {
+        border-spacing: 0;
+        border-collapse: collapse;
+        border-bottom: 3px solid #005a9c;
+      }
+
+      .simple th {
+        background: #005a9c;
+        color: #fff;
+        padding: 3px 5px;
+        text-align: left;
+      }
+
+      .simple th a {
+        color: #fff;
+        padding: 3px 5px;
+        text-align: left;
+      }
+
+      .simple th[scope='row'] {
+        background: inherit;
+        color: inherit;
+        border-top: 1px solid #ddd;
+      }
+
+      .simple td {
+        padding: 3px 10px;
+        border-top: 1px solid #ddd;
+      }
+
+      .simple tr:nth-child(even) {
+        background: #f0f6ff;
+      }
+
+      /* --- DL --- */
+
+      .section dd > p:first-child {
+        margin-top: 0;
+      }
+
+      .section dd > p:last-child {
+        margin-bottom: 0;
+      }
+
+      .section dd {
+        margin-bottom: 1em;
+      }
+
+      .section dl.attrs dd,
+      .section dl.eldef dd {
+        margin-bottom: 0;
+      }
+
+      #issue-summary > ul,
+      .respec-dfn-list {
+        column-count: 2;
+      }
+
+      #issue-summary li,
+      .respec-dfn-list li {
+        list-style: none;
+      }
+
+      details.respec-tests-details {
+        margin-left: 1em;
+        display: inline-block;
+        vertical-align: top;
+      }
+
+      details.respec-tests-details > * {
+        padding-right: 2em;
+      }
+
+      details.respec-tests-details[open] {
+        z-index: 999999;
+        position: absolute;
+        border: thin solid #cad3e2;
+        border-radius: 0.3em;
+        background-color: white;
+        padding-bottom: 0.5em;
+      }
+
+      details.respec-tests-details[open] > summary {
+        border-bottom: thin solid #cad3e2;
+        padding-left: 1em;
+        margin-bottom: 1em;
+        line-height: 2em;
+      }
+
+      details.respec-tests-details > ul {
+        width: 100%;
+        margin-top: -0.3em;
+      }
+
+      details.respec-tests-details > li {
+        padding-left: 1em;
+      }
+
+      a[href].self-link:hover {
+        opacity: 1;
+        text-decoration: none;
+        background-color: transparent;
+      }
+
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        position: relative;
+      }
+
+      aside.example .marker > a.self-link {
+        color: inherit;
+      }
+
+      h2 > a.self-link,
+      h3 > a.self-link,
+      h4 > a.self-link,
+      h5 > a.self-link,
+      h6 > a.self-link {
+        border: none;
+        color: inherit;
+        font-size: 83%;
+        height: 2em;
+        left: -1.6em;
+        opacity: 0.5;
+        position: absolute;
+        text-align: center;
+        text-decoration: none;
+        top: 0;
+        transition: opacity 0.2s;
+        width: 2em;
+      }
+
+      h2 > a.self-link::before,
+      h3 > a.self-link::before,
+      h4 > a.self-link::before,
+      h5 > a.self-link::before,
+      h6 > a.self-link::before {
+        content: '§';
+        display: block;
+      }
+
+      @media (max-width: 767px) {
+        dd {
+          margin-left: 0;
+        }
+
+        /* Don't position self-link in headings off-screen */
+        h2 > a.self-link,
+        h3 > a.self-link,
+        h4 > a.self-link,
+        h5 > a.self-link,
+        h6 > a.self-link {
+          left: auto;
+          top: auto;
+        }
+      }
+
+      @media print {
+        .removeOnSave {
+          display: none;
+        }
+      }
+    </style>
+
+    <style>
+      .transheader {
+        display: block;
+        border: solid #ccccbb;
+        margin-bottom: 2em;
+        padding: 2%;
+        background: #eeeedd;
+      }
+
+      .transtitle {
+        color: #555555;
+        background: #eeeedd;
+        font-weight: bolder;
+      }
+    </style>
+
+    <style>
+      .conformance-level {
+        display: inline;
+      }
+
+      .change {
+        display: inline;
+      }
+
+      .doclinks {
+        float: right;
+        border: thin solid black;
+        font-size: x-small;
+        display: block;
+        width: 25%;
+        hyphens: none;
+      }
+      .sc dt {
+        display: list-item;
+        list-style-type: disc;
+        float: left;
+        font-weight: bold;
+        margin-left: 2em;
+        margin-right: 1ex;
+        line-height: 1.5;
+      }
+      .sc dt:after {
+        content: ':';
+      }
+      div.note-title,
+      div.ednote-title {
+        color: #008400;
+      }
+      span.screenreader {
+        position: absolute;
+        left: -10000px;
+      }
+
+      /* Fix accessibility */
+      /* Increase specificity with top html */
+      html #toc-nav:not(:hover) > a:not(:focus) > span + span {
+        display: block;
+        position: absolute;
+        top: auto;
+        left: -999999px;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+    </style>
+    <meta
+      name="description"
+      content="De Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.2 bevatten
+        een groot aantal aanbevelingen om webcontent toegankelijker te maken.
+        Het volgen van deze richtlijnen maakt content toegankelijker voor meer
+        mensen met functiebeperkingen, waaronder blindheid en slechtziendheid,
+        doofheid en gehoorverlies, leerproblemen, cognitieve beperkingen,
+        motorische beperkingen, spraakproblemen, overgevoeligheid voor licht en
+        combinaties daarvan; maar het voorziet niet in elke gebruikersbehoefte
+        van mensen met deze beperkingen. Deze richtlijnen zijn van toepassing op
+        de toegankelijkheid van webcontent op computers, laptops, tablets en
+        mobiele apparaten. Het volgen van deze richtlijnen maakt webcontent
+        doorgaans ook beter bruikbaar voor gebruikers in het algemeen."
+    />
+    <link rel="canonical" href="https://www.w3.org/TR/WCAG21/" />
+    <style>
+      var {
+        position: relative;
+        cursor: pointer;
+      }
+
+      var[data-type]::before,
+      var[data-type]::after {
+        position: absolute;
+        left: 50%;
+        top: -6px;
+        opacity: 0;
+        transition: opacity 0.4s;
+        pointer-events: none;
+      }
+
+      /* the triangle or arrow or caret or whatever */
+      var[data-type]::before {
+        content: '';
+        transform: translateX(-50%);
+        border-width: 4px 6px 0 6px;
+        border-style: solid;
+        border-color: transparent;
+        border-top-color: #000;
+      }
+
+      /* actual text */
+      var[data-type]::after {
+        content: attr(data-type);
+        transform: translateX(-50%) translateY(-100%);
+        background: #000;
+        text-align: center;
+        /* additional styling */
+        font-family: 'Dank Mono', 'Fira Code', monospace;
+        font-style: normal;
+        padding: 6px;
+        border-radius: 3px;
+        color: #daca88;
+        text-indent: 0;
+        font-weight: normal;
+      }
+
+      var[data-type]:hover::after,
+      var[data-type]:hover::before {
+        opacity: 1;
+      }
+    </style>
+    <script id="initialUserConfig" type="application/json">
+      {
+        "trace": true,
+        "useExperimentalStyles": true,
+        "doRDFa": "1.1",
+        "includePermalinks": true,
+        "permalinkEdge": true,
+        "permalinkHide": false,
+        "tocIntroductory": true,
+        "specStatus": "REC",
+        "crEnd": "2020/01/02",
+        "implementationReportURI": "https://www.w3.org/WAI/WCAG21/implementation-report/",
+        "diffTool": "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+        "shortName": "WCAG21",
+        "copyrightStart": "2017",
+        "license": "document",
+        "previousPublishDate": "2018-04-24",
+        "previousMaturity": "PR",
+        "prevRecURI": "https://www.w3.org/TR/2008/REC-WCAG20-20081211/",
+        "edDraftURI": "https://w3c.github.io/wcag21/guidelines/",
+        "editors": [
+          {
+            "name": "Andrew Kirkpatrick",
+            "url": "http://www.adobe.com/",
+            "company": "Adobe",
+            "companyURI": "http://www.adobe.com/",
+            "w3cid": 39770
+          },
+          {
+            "name": "Joshue O Connor",
+            "url": "http://interaccess.ie/",
+            "company": "Invited Expert, InterAccess",
+            "companyURI": "http://interaccess.ie/",
+            "w3cid": 41218
+          },
+          {
+            "name": "Alastair Campbell",
+            "url": "https://www.nomensa.com/",
+            "company": "Nomensa",
+            "companyURI": "https://www.nomensa.com/",
+            "w3cid": 44689
+          },
+          {
+            "name": "Michael Cooper",
+            "url": "https://www.w3.org",
+            "company": "W3C",
+            "companyURI": "https://www.w3.org",
+            "w3cid": 34017
+          }
+        ],
+        "formerEditors": [
+          {
+            "name": "Ben Caldwell",
+            "company": "Trace R&D Center, University of Wisconsin-Madison",
+            "w3cid": 33602
+          },
+          {
+            "name": "Loretta Guarino Reid",
+            "company": "Google, Inc.",
+            "w3cid": 35436
+          },
+          {
+            "name": "Gregg Vanderheiden",
+            "company": "Trace R&D Center, University of Wisconsin-Madison",
+            "w3cid": 3442
+          },
+          {
+            "name": "Wendy Chisholm",
+            "company": "W3C",
+            "w3cid": 4099
+          },
+          {
+            "name": "John Slatin",
+            "company": "Accessibility Institute, University of Texas at Austin",
+            "w3cid": 35537
+          },
+          {
+            "name": "Jason White",
+            "company": "University of Melbourne",
+            "w3cid": 74028
+          }
+        ],
+        "wg": "Accessibility Guidelines Working Group",
+        "wgURI": "https://www.w3.org/WAI/GL/",
+        "wgPublicList": "public-comments-wcag20",
+        "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/35422/status",
+        "maxTocLevel": 4,
+        "localBiblio": {
+          "CAPTCHA": {
+            "href": "http://www.captcha.net/",
+            "publisher": "Carnegie Mellon University",
+            "title": "The CAPTCHA Project"
+          },
+          "GPII": {
+            "href": "https://gpii.net/",
+            "title": "Global Public Inclusive Infrastructure"
+          },
+          "HARDING-BINNIE": {
+            "authors": ["Harding G. F. A.", "Binnie, C.D."],
+            "date": "2002",
+            "title": "Independent Analysis of the ITC Photosensitive Epilepsy Calibration Test Tape",
+            "id": "harding-binnie"
+          },
+          "IEC-4WD": {
+            "date": "May 5, 1998",
+            "title": "IEC/4WD 61966-2-1: Colour Measurement and Management in Multimedia Systems and Equipment - Part 2.1: Default Colour Space - sRGB",
+            "id": "iec-4wd"
+          },
+          "ISO_9241-112": {
+            "uri": "https://www.iso.org/standard/64840.html",
+            "title": "Ergonomics of human-system interaction -- Part 112: Principles for the presentation of information",
+            "publisher": "International Standards Organization"
+          },
+          "sRGB": {
+            "authors": [
+              "M. Stokes",
+              "M. Anderson",
+              "S. Chandrasekar",
+              "R. Motta"
+            ],
+            "date": "November 5, 1996",
+            "href": "https://www.w3.org/Graphics/Color/sRGB.html",
+            "title": "A Standard Default Color Space for the Internet - sRGB, Version 1.10",
+            "id": "srgb"
+          },
+          "UNESCO": {
+            "date": "1997",
+            "href": "http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm",
+            "title": "International Standard Classification of Education",
+            "id": "unesco"
+          }
+        },
+        "postProcess": [null, null, null, null, null, null, null],
+        "publishISODate": "2020-03-19T00:00:00.000Z",
+        "generatedSubtitle": "Recommendation 19 March 2020"
+      }
+    </script>
+    <link
+      rel="stylesheet"
+      href="https://www.w3.org/StyleSheets/TR/2016/W3C-REC"
+    />
+  </head>
+
+  <body class="h-entry informative">
+    <div class="transheader">
+      <h1 class="transtitle" lang="en">
+        Web Content Accessibility Guidelines (WCAG) 2.2
+      </h1>
+      <dl lang="en">
+        <dt>
+          <strong>Lead translating organization:</strong>
+        </dt>
+        <dd>
+          Accessibility Foundation<br />
+          Expertise center for quality and accessibility of internet and
+          software<br />
+          Christiaan Krammlaan 2<br />
+          3571 AX Utrecht (The Netherlands)<br />
+          Tel: +31 (0)30 – 2398270<br />
+          Website:
+          <a hreflang="nl" href="https://www.accessibility.nl">https://www.accessibility.nl</a><br />
+          Eric Velleman, Technical Director
+        </dd>
+      </dl>
+
+      <h1 class="transtitle">
+        Geautoriseerde Nederlandse vertaling
+      </h1>
+      <h2 class="transtitle">
+        <time datetime="2020-05-26" title="26 Mei 2020">26 Mei 2020</time>
+      </h2>
+
+      <dl>
+        <dt>
+          <strong>Deze versie:</strong>
+        </dt>
+        <dd>
+          <a href="https://www.w3.org/Translations/WCAG21-nl-20200526/">https://www.w3.org/Translations/WCAG21-nl-20200526/</a>
+        </dd>
+
+        <dt>
+          <strong>Meest recente versie:</strong>
+        </dt>
+        <dd>
+          <a href="https://www.w3.org/Translations/WCAG21-nl/">https://www.w3.org/Translations/WCAG21-nl/</a>
+        </dd>
+
+        <dt>
+          <strong>Originele versie (Engels):</strong>
+        </dt>
+        <dd>
+          <a href="https://www.w3.org/TR/2023/REC-WCAG22-20231005/ " hreflang="en">https://www.w3.org/TR/2023/REC-WCAG22-20231005/</a>
+        </dd>
+
+        <dt>
+          <strong>Errata:</strong>
+        </dt>
+        <dd>
+          <a href="https://accessibilitynl.github.io/WCAG21-NL/translations/WCAG21-nl/errata/">https://accessibilitynl.github.io/WCAG21-NL/translations/WCAG21-nl/errata/</a>
+        </dd>
+      </dl>
+
+      <dl>
+        <dt>
+          <strong>Vertaling leidende organisatie:</strong>
+        </dt>
+        <dd>
+          Stichting Accessibility<br />
+          Expertisecentrum op het gebied van kwaliteit en toegankelijkheid van
+          ICT<br />
+          Christiaan Krammlaan 2<br />
+          3571 AX Utrecht (Nederland)<br />
+          Tel: +31 (0)30 – 2398270<br />
+          Website:
+          <a href="https://www.accessibility.nl">https://www.accessibility.nl</a><br />
+          Eric Velleman, Wetenschappelijk directeur
+        </dd>
+
+        <dt>
+          <strong>Partners in de vertaling en de review:</strong>
+        </dt>
+        <dd>
+          Zie de
+          <a href="https://lists.w3.org/Archives/Public/w3c-translators/2020AprJun/0012.html" hreflang="en">stakeholdersmail</a>
+          voor een overzicht van de partners.
+        </dd>
+        <dt>
+          <strong>Samenvatting van publieke commentaren op de kandidaat
+            geautoriseerde vertaling:</strong>
+        </dt>
+
+        <dd>
+          Zie de
+          <a hreflang="en" href="https://lists.w3.org/Archives/Public/public-auth-trans-nl/2020Feb/0000.html">bijlage met commentaren</a>
+          en de verwerking daarvan bij de bekendmaking van de kandidaat
+          vertaling.
+        </dd>
+      </dl>
+
+      <p>
+        Dit is een geautoriseerde vertaling van een
+        <abbr title="World Wide Web Consortium">W3C</abbr> document. De
+        publicatie van deze vertaling volgt de stappen die beschreven zijn in de
+        <a href="https://www.w3.org/2005/02/TranslationPolicy.html" lang="en-US" xml:lang="en-US" hreflang="en">Policy for
+          <abbr title="World Wide Web Consortium">W3C</abbr> Authorized
+          translations</a>. Als zich geschillen voordoen is de versie van de specificatie in het
+        originele Engelse document gezaghebbend.
+      </p>
+    </div>
+    <div class="head" id="">
+      <a href="https://www.w3.org/" class="logo">
+        <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" />
+      </a>
+
+      <h1 id="title" class="title p-name">
+        Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.2
+      </h1>
+      <h2 id="w3c-recommendation-05-june-2018">
+        <abbr title="World Wide Web Consortium">W3C</abbr> Aanbeveling
+        <time class="dt-published" datetime="2018-06-05">05 Oktober 2023</time>
+      </h2>
+      <dl>
+        <dt>Deze versie (Engels):</dt>
+        <dd>
+          <a class="u-url" href="https://www.w3.org/TR/2023/REC-WCAG22-20231005/">https://www.w3.org/TR/2023/REC-WCAG22-20231005/</a>
+        </dd>
+        <dt>Laatst gepubliceerde versie (Engels):</dt>
+        <dd>
+          <a href="https://www.w3.org/TR/WCAG22/">https://www.w3.org/TR/WCAG22/</a>
+        </dd>
+        <dt>Laatste werkversie (Engels):</dt>
+        <dd>
+          <a href="https://w3c.github.io/wcag/guidelines/22/">https://w3c.github.io/wcag/guidelines/22/</a>
+        </dd>
+
+        <dt>Implementatie rapport (Engels):</dt>
+        <dd>
+          <a href="https://www.w3.org/WAI/WCAG21/implementation-report/">https://www.w3.org/WAI/WCAG21/implementation-report/</a>
+        </dd>
+
+        <dt>Vorige versie (Engels):</dt>
+        <dd>
+          <a href="https://www.w3.org/TR/2018/PR-WCAG21-20180424/">https://www.w3.org/TR/2018/PR-WCAG21-20180424/</a>
+        </dd>
+        <dt>Vorige aanbeveling (Engels):</dt>
+        <dd>
+          <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>
+        </dd>
+        <dt>Redacteuren:</dt>
+        <dd class="p-author h-card vcard" data-editor-id="39770">
+          Andrew Kirkpatrick (Adobe)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="41218">
+          Joshue O Connor (Invited Expert, InterAccess)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="44689">
+          Alastair Campbell (Nomensa)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="34017">
+          Michael Cooper (<abbr title="World Wide Web Consortium">W3C</abbr>)
+        </dd>
+        <dt>
+          Voorgaande Redacteuren:
+        </dt>
+        <dd class="p-author h-card vcard" data-editor-id="33602">
+          <span class="p-name fn">Ben Caldwell</span>
+          (Trace R&amp;D Center, University of Wisconsin-Madison)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="35436">
+          <span class="p-name fn">Loretta Guarino Reid</span>
+          (Google, Inc.)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="3442">
+          <span class="p-name fn">Gregg Vanderheiden</span>
+          (Trace R&amp;D Center, University of Wisconsin-Madison)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="4099">
+          <span class="p-name fn">Wendy Chisholm</span>
+          (<abbr title="World Wide Web Consortium">W3C</abbr>)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="35537">
+          <span class="p-name fn">John Slatin</span>
+          (Accessibility Institute, University of Texas at Austin)
+        </dd>
+        <dd class="p-author h-card vcard" data-editor-id="74028">
+          <span class="p-name fn">Jason White</span>
+          (University of Melbourne)
+        </dd>
+      </dl>
+
+      <p>
+        Zie ook de
+        <a href="https://www.w3.org/WAI/WCAG21/errata/"><strong>errata</strong></a>
+        voor dit document, waaronder mogelijk normatieve correcties.
+      </p>
+
+      <p>
+        Zie ook
+        <a href="https://www.w3.org/WAI/standards-guidelines/wcag/translations/" hreflang="en">
+          <strong>andere vertalingen</strong></a>.
+      </p>
+
+      <p>
+        Dit document is ook in non-normatieve formaten (Engels) beschikbaar
+        vanuit
+        <a href="https://www.w3.org/WAI/WCAG21/versions/" lang="en" hreflang="en">Alternate Versions of Web Content Accessibility Guidelines 2.1</a>.
+      </p>
+
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
+        © 2020-2023
+
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>(<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>).
+
+        <abbr title="World Wide Web Consortium">W3C</abbr>
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer" hreflang="en">aansprakelijkheid</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks" hreflang="en">handelsmerken</a>
+        en
+        <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents" hreflang="en">gebruik van documenten</a>
+        zijn van toepassing.
+      </p>
+      <hr title="Separator for header" />
+    </div>
+
+    <section id="samenvatting" class="introductory">
+      <h2>Samenvatting</h2>
+
+      <p>
+        De Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.2 bevatten
+        een groot aantal aanbevelingen om webcontent toegankelijker te maken.
+        Het volgen van deze richtlijnen maakt content toegankelijker voor meer
+        mensen met functiebeperkingen, waaronder blindheid en slechtziendheid,
+        doofheid en gehoorverlies, leerproblemen, cognitieve beperkingen,
+        motorische beperkingen, spraakproblemen, overgevoeligheid voor licht en
+        combinaties daarvan; maar het voorziet niet in elke gebruikersbehoefte
+        van mensen met deze beperkingen. Deze richtlijnen zijn van toepassing op
+        de toegankelijkheid van webcontent op computers, laptops, tablets en
+        mobiele apparaten. Het volgen van deze richtlijnen maakt webcontent
+        doorgaans ook beter bruikbaar voor gebruikers in het algemeen.
+      </p>
+      <p>
+        Succescriteria van WCAG 2.2 zijn toetsbaar geformuleerd en zijn niet
+        gebonden aan een technologie.
+        <abbr title="World Wide Web Consortium">W3C</abbr> levert in aparte
+        documenten ondersteuning voor het voldoen aan de succescriteria bij
+        gebruik van specifieke technologieën en algemene informatie over de
+        interpretatie van de succescriteria. Zie het
+        <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a>
+        voor een inleiding en links naar technisch en educatief WCAG-materiaal.
+      </p>
+      <p>
+        Dit document, de Nederlandse vertaling van WCAG 2.2, is een uitbreiding
+        van de
+        <a href="https://www.w3.org/Translations/WCAG20-nl/">Richtlijnen voor Toegankelijkheid van Webcontent 2.1</a>
+        [<cite><a class="bibref" href="#bib-wcag20" title="Web Content Accessibility Guidelines (WCAG) 2.0" data-link-type="biblio">WCAG20</a></cite>]. Dit is de Nederlandse vertaling van de Web Content Accessibility
+        Guidelines (WCAG) 2.0, gepubliceerd als
+        <abbr title="World Wide Web Consortium">W3C</abbr> Aanbeveling in
+        december 2008. De content die voldoet aan WCAG 2.1 voldoet ook aan WCAG
+        2.0. De WG (Werkgroep) wil dat voor beleid dat conformiteit met WCAG 2.0
+        vereist, WCAG 2.1 als alternatief voor conformiteit kan worden gebruikt.
+        De publicatie van WCAG 2.1 leidt niet tot de afschaffing of vervanging
+        van WCAG 2.0. Hoewel WCAG 2.0 een
+        <abbr title="World Wide Web Consortium">W3C</abbr> Aanbeveling blijft,
+        beveelt het <abbr title="World Wide Web Consortium">W3C</abbr> het
+        gebruik van WCAG 2.1 aan om de toepassing van toegankelijkheid in de
+        toekomst te maximaliseren. Het
+        <abbr title="World Wide Web Consortium">W3C</abbr> moedigt daarnaast het
+        gebruik van de meest recente versie van WCAG aan bij het ontwikkelen of
+        bijwerken van beleid over webtoegankelijkheid.
+      </p>
+    </section>
+
+    <section id="sotd" class="introductory"><h2>Status van dit document</h2><p><em>Deze paragraaf beschrijft de status van dit document op het moment van publicatie. Andere documenten kunnen de plaats van dit document innemen. Een lijst van de huidige <abbr title="World Wide Web Consortium">W3C-publicaties</abbr>
+      en de laatste revisie van dit technische rapport is te vinden in de <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C-index</abbr> in</a> https://www.w3.org/TR/.</em></p>
+         
+         <p>Commentaar kan worden gegeven door een issue aan te maken in het <a href="https://github.com/w3c/wcag/issues/new">W3C WCAG Github-Repository
+               <abbr title="World Wide Web Consortium"></abbr></a>.
+               De Werkgroep verzoekt om publieke commentaren als nieuwe issue te registreren; 1 issue per afzonderlijk commentaar. Gebruikers kunnen gratis een GitHub-account aanmaken om issues te registreren. Als het niet mogelijk is om issues te registreren in GitHub, stuur dan een e-mail naar <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%202.1%20public%20comment">public-agwg-comments@w3.org</a> <a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">(archief voor commentaar).</a>
+         </p>
+         
+      <p>
+    Dit document is gepubliceerd door de <a href="https://www.w3.org/groups/wg/ag">Accessibility Guidelines Working Group</a> als een
+        <a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Aanbeveling</a>. 
+  </p><p>
+      <abbr title="World Wide Web Consortium">W3C</abbr> beveelt aan om deze specificatie breed in te zetten als standaard voor het web. 
+    </p><p>
+      Een <abbr title="World Wide Web Consortium">W3C</abbr> Aanbeveling is een specificatie die, na uitgebreide consesusvorming, wordt goedgekeurd door
+      <abbr title="World Wide Web Consortium">W3C</abbr> en haar leden, waarbij de leden van de werkgroep zich committeren aan
+      <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-vrije licenties</a>
+      voor implementaties.
+      
+    </p><p>
+    
+      Dit document is gemaakt door een groep die werkte onder het W3C-patentbeleid (W3C Patent Policy) van
+        <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">1 August 2017. <abbr title="World Wide Web Consortium"></abbr></a><abbr title="World Wide Web Consortium">Het W3C</abbr> onderhoudt een
+                <a rel="disclosure" href="https://www.w3.org/groups/wg/ag/ipr">publieke lijst van alle patentmeldingen die</a>
+                in verband met de afgeleverde producten van de groep zijn gemaakt; die pagina bevat ook instructies om een patent te melden. Een persoon die feitelijke kennis heeft van een patent dat volgens die persoon Essentiële Aanspraken (Essential Claim(s)) bevat,
+          <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a>
+          moet de informatie overeenkomstig
+          <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">paragraaf 6 van het <abbr title="World Wide Web Consortium">W3C</abbr> patentbeleid melden</a>.
+        
+  </p><p>
+    Dit document valt onder het
+                  <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">W3C Process Document van 12 juni 2023<abbr title="World Wide Web Consortium"></abbr></a>.
+                </p></section>
+    <nav id="toc">
+      <h2 class="introductory" id="inhoudsopgave">Inhoudsopgave</h2>
+      <ol class="toc">
+        <li class="tocline">
+          <a class="tocxref" href="#samenvatting">Samenvatting</a>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#status-van-dit-document">Status van dit document</a>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#inleiding">Inleiding</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#achtergrond-van-wcag-2"><bdi class="secno">0.1 </bdi>Achtergrond van WCAG 2</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#de-gelaagde-structuur-van-wcag-2"><bdi class="secno">0.2 </bdi>De gelaagde structuur van WCAG
+                2</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#documenten-die-wcag-2-1-ondersteunen"><bdi class="secno">0.3 </bdi>Documenten die WCAG 2.1
+                ondersteunen</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#eisen-aan-wcag-2-1"><bdi class="secno">0.4 </bdi>Eisen aan WCAG 2.1</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#vergelijking-met-wcag-2-0"><bdi class="secno">0.5 </bdi>Vergelijking met WCAG 2.0</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#nieuwe-kenmerken-in-wcag-2-1"><bdi class="secno">0.5.1 </bdi>Nieuwe kenmerken in WCAG
+                    2.1</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#nummering-in-wcag-2-1"><bdi class="secno">0.5.2 </bdi>Nummering in WCAG 2.1</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#conformiteit-met-wcag-2-1"><bdi class="secno">0.5.3 </bdi>Conformiteit met WCAG 2.1</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#latere-versies-van-de-richtlijnen-voor-toegankelijkheid"><bdi class="secno">0.6 </bdi>Latere versies van de Richtlijnen
+                voor Toegankelijkheid</a>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#waarneembaar"><bdi class="secno">1. </bdi>Waarneembaar</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#tekstalternatieven"><bdi class="secno">1.1 </bdi>Tekstalternatieven</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#niet-tekstuele-content"><bdi class="secno">1.1.1 </bdi>Niet-tekstuele content</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#op-tijd-gebaseerde-media"><bdi class="secno">1.2 </bdi>Op tijd gebaseerde media</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#louter-geluid-en-louter-videobeeld-vooraf-opgenomen"><bdi class="secno">1.2.1 </bdi>Louter-geluid en
+                    louter-videobeeld (vooraf opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#ondertitels-voor-doven-en-slechthorenden-vooraf-opgenomen"><bdi class="secno">1.2.2 </bdi>Ondertitels voor doven en
+                    slechthorenden (vooraf opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#audiodescriptie-of-media-alternatief-vooraf-opgenomen"><bdi class="secno">1.2.3 </bdi>Audiodescriptie of
+                    media-alternatief (vooraf opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#ondertitels-voor-doven-en-slechthorenden-live"><bdi class="secno">1.2.4 </bdi>Ondertitels voor doven en
+                    slechthorenden (live)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#audiodescriptie-vooraf-opgenomen"><bdi class="secno">1.2.5 </bdi>Audiodescriptie (vooraf
+                    opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#gebarentaal-vooraf-opgenomen"><bdi class="secno">1.2.6 </bdi>Gebarentaal (vooraf
+                    opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#verlengde-audiodescriptie-vooraf-opgenomen"><bdi class="secno">1.2.7 </bdi>Verlengde audiodescriptie
+                    (vooraf opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#media-alternatief-vooraf-opgenomen"><bdi class="secno">1.2.8 </bdi>Media-alternatief (vooraf
+                    opgenomen)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#louter-geluid-live"><bdi class="secno">1.2.9 </bdi>Louter-geluid (live)</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#aanpasbaar"><bdi class="secno">1.3 </bdi>Aanpasbaar</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#info-en-relaties"><bdi class="secno">1.3.1 </bdi>Info en relaties</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#betekenisvolle-volgorde"><bdi class="secno">1.3.2 </bdi>Betekenisvolle volgorde</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#zintuiglijke-eigenschappen"><bdi class="secno">1.3.3 </bdi>Zintuiglijke
+                    eigenschappen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#weergavestand"><bdi class="secno">1.3.4 </bdi>Weergavestand</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#identificeer-het-doel-van-de-input"><bdi class="secno">1.3.5 </bdi>Identificeer het doel van de
+                    input</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#identificeer-het-doel"><bdi class="secno">1.3.6 </bdi>Identificeer het doel</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#onderscheidbaar"><bdi class="secno">1.4 </bdi>Onderscheidbaar</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#gebruik-van-kleur"><bdi class="secno">1.4.1 </bdi>Gebruik van kleur</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#geluidsbediening"><bdi class="secno">1.4.2 </bdi>Geluidsbediening</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#contrast-minimum"><bdi class="secno">1.4.3 </bdi>Contrast (minimum)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#herschalen-van-tekst"><bdi class="secno">1.4.4 </bdi>Herschalen van tekst</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#afbeeldingen-van-tekst"><bdi class="secno">1.4.5 </bdi>Afbeeldingen van tekst</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#contrast-versterkt"><bdi class="secno">1.4.6 </bdi>Contrast (versterkt)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#weinig-of-geen-achtergrondgeluid"><bdi class="secno">1.4.7 </bdi>Weinig of geen
+                    achtergrondgeluid</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#visuele-weergave"><bdi class="secno">1.4.8 </bdi>Visuele weergave</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#afbeeldingen-van-tekst-geen-uitzondering"><bdi class="secno">1.4.9 </bdi>Afbeeldingen van tekst (geen
+                    uitzondering)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#reflow"><bdi class="secno">1.4.10 </bdi>Reflow</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#contrast-van-niet-tekstuele-content"><bdi class="secno">1.4.11 </bdi>Contrast van niet-tekstuele
+                    content</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#tekstafstand"><bdi class="secno">1.4.12 </bdi>Tekstafstand</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#content-bij-hover-of-focus"><bdi class="secno">1.4.13 </bdi>Content bij hover of
+                    focus</a>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#bedienbaar"><bdi class="secno">2. </bdi>Bedienbaar</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#toetsenbordtoegankelijk"><bdi class="secno">2.1 </bdi>Toetsenbordtoegankelijk</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#toetsenbord"><bdi class="secno">2.1.1 </bdi>Toetsenbord</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#geen-toetsenbordval"><bdi class="secno">2.1.2 </bdi>Geen toetsenbordval</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#toetsenbord-geen-uitzondering"><bdi class="secno">2.1.3 </bdi>Toetsenbord (geen
+                    uitzondering)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#enkel-teken-sneltoetsen"><bdi class="secno">2.1.4 </bdi>Enkel teken sneltoetsen</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#genoeg-tijd"><bdi class="secno">2.2 </bdi>Genoeg tijd</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#timing-aanpasbaar"><bdi class="secno">2.2.1 </bdi>Timing aanpasbaar</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#pauzeren-stoppen-verbergen"><bdi class="secno">2.2.2 </bdi>Pauzeren, stoppen,
+                    verbergen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#geen-timing"><bdi class="secno">2.2.3 </bdi>Geen timing</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#onderbrekingen"><bdi class="secno">2.2.4 </bdi>Onderbrekingen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#herauthentisering"><bdi class="secno">2.2.5 </bdi>Herauthentisering</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#time-outs"><bdi class="secno">2.2.6 </bdi>Time-outs</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#toevallen-en-fysieke-reacties"><bdi class="secno">2.3 </bdi>Toevallen en fysieke reacties</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#drie-flitsen-of-beneden-drempelwaarde"><bdi class="secno">2.3.1 </bdi>Drie flitsen of beneden
+                    drempelwaarde</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#drie-flitsen"><bdi class="secno">2.3.2 </bdi>Drie flitsen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#animatie-uit-interacties"><bdi class="secno">2.3.3 </bdi>Animatie uit interacties</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#navigeerbaar"><bdi class="secno">2.4 </bdi>Navigeerbaar</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#blokken-omzeilen"><bdi class="secno">2.4.1 </bdi>Blokken omzeilen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#paginatitel"><bdi class="secno">2.4.2 </bdi>Paginatitel</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#focus-volgorde"><bdi class="secno">2.4.3 </bdi>Focus volgorde</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#linkdoel-in-context"><bdi class="secno">2.4.4 </bdi>Linkdoel (in context)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#meerdere-manieren"><bdi class="secno">2.4.5 </bdi>Meerdere manieren</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#koppen-en-labels"><bdi class="secno">2.4.6 </bdi>Koppen en labels</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#focus-zichtbaar"><bdi class="secno">2.4.7 </bdi>Focus zichtbaar</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#locatie"><bdi class="secno">2.4.8 </bdi>Locatie</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#linkdoel-alleen-link"><bdi class="secno">2.4.9 </bdi>Linkdoel (alleen link)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#paragraafkoppen"><bdi class="secno">2.4.10 </bdi>Paragraafkoppen</a>
+                </li>
+                <li class="tocline"><a class="tocxref" href="#focus-not-obscured-minimum"><bdi class="secno">2.4.11 </bdi>Focus niet bedekt (Minimum)</a></li>
+                <li class="tocline"><a class="tocxref" href="#focus-not-obscured-enhanced"><bdi class="secno">2.4.12 </bdi>Focus niet bedekt (Enhanced)</a></li>
+                <li class="tocline"><a class="tocxref" href="#focus-appearance"><bdi class="secno">2.4.13 </bdi>Focusweergave</a></li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#input-modaliteiten"><bdi class="secno">2.5 </bdi>Input Modaliteiten</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#aanwijzergebaren"><bdi class="secno">2.5.1 </bdi>Aanwijzergebaren</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#aanwijzerannulering"><bdi class="secno">2.5.2 </bdi>Aanwijzerannulering</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#label-in-naam"><bdi class="secno">2.5.3 </bdi>Label in naam</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#bewegingsactivering"><bdi class="secno">2.5.4 </bdi>Bewegingsactivering</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#grootte-van-het-aanwijsgebied"><bdi class="secno">2.5.5 </bdi>Grootte van het
+                    aanwijsgebied</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#input-gelijktijdige-invoermechanismen"><bdi class="secno">2.5.6 </bdi>Input gelijktijdige
+                    invoermechanismen</a>
+                </li>
+                <li class="tocline"><a class="tocxref" href="#dragging-movements"><bdi class="secno">2.5.7 </bdi>Sleepbewegingen</a></li>
+                <li class="tocline"><a class="tocxref" href="#target-size-minimum"><bdi class="secno">2.5.8 </bdi>grootte van het aanwijsgebied (Minimum)</a></li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#begrijpelijk"><bdi class="secno">3. </bdi>Begrijpelijk</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#leesbaar"><bdi class="secno">3.1 </bdi>Leesbaar</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#taal-van-de-pagina"><bdi class="secno">3.1.1 </bdi>Taal van de pagina</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#taal-van-onderdelen"><bdi class="secno">3.1.2 </bdi>Taal van onderdelen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#ongebruikelijke-woorden"><bdi class="secno">3.1.3 </bdi>Ongebruikelijke woorden</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#afkortingen"><bdi class="secno">3.1.4 </bdi>Afkortingen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#leesniveau"><bdi class="secno">3.1.5 </bdi>Leesniveau</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#uitspraak"><bdi class="secno">3.1.6 </bdi>Uitspraak</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#voorspelbaar"><bdi class="secno">3.2 </bdi>Voorspelbaar</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#bij-focus"><bdi class="secno">3.2.1 </bdi>Bij focus</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#bij-input"><bdi class="secno">3.2.2 </bdi>Bij input</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#consistente-navigatie"><bdi class="secno">3.2.3 </bdi>Consistente navigatie</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#consistente-identificatie"><bdi class="secno">3.2.4 </bdi>Consistente identificatie</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#verandering-op-verzoek"><bdi class="secno">3.2.5 </bdi>Verandering op verzoek</a>
+                </li>
+                <li class="tocline"><a class="tocxref" href="#consistent-help"><bdi class="secno">3.2.6 </bdi>Consistente hulp</a></li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#assistentie-bij-invoer"><bdi class="secno">3.3 </bdi>Assistentie bij invoer</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#foutidentificatie"><bdi class="secno">3.3.1 </bdi>Foutidentificatie</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#labels-of-instructies"><bdi class="secno">3.3.2 </bdi>Labels of instructies</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#foutsuggestie"><bdi class="secno">3.3.3 </bdi>Foutsuggestie</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#foutpreventie-wettelijk-financieel-gegevens"><bdi class="secno">3.3.4 </bdi>Foutpreventie (wettelijk,
+                    financieel, gegevens)</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#hulp"><bdi class="secno">3.3.5 </bdi>Hulp</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#foutpreventie-alle"><bdi class="secno">3.3.6 </bdi>Foutpreventie (alle)</a>
+                </li>
+                <li class="tocline"><a class="tocxref" href="#redundant-entry"><bdi class="secno">3.3.7 </bdi>Overbodige invoer</a></li>
+                <li class="tocline"><a class="tocxref" href="#accessible-authentication-minimum"><bdi class="secno">3.3.8 </bdi>Toegankelijke authenticatie (Minimum)</a></li>
+                <li class="tocline"><a class="tocxref" href="#accessible-authentication-enhanced"><bdi class="secno">3.3.9 </bdi>Toegankelijke authenticatie (Enhanced)</a></li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#robuust"><bdi class="secno">4. </bdi>Robuust</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#compatibel"><bdi class="secno">4.1 </bdi>Compatibel</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#parsen"><bdi class="secno">4.1.1 </bdi>Parsen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#naam-rol-waarde"><bdi class="secno">4.1.2 </bdi>Naam, rol, waarde</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#statusberichten"><bdi class="secno">4.1.3 </bdi>Statusberichten</a>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#conformiteit"><bdi class="secno">5. </bdi>Conformiteit</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#normatieve-eisen-interpreteren"><bdi class="secno">5.1 </bdi>Normatieve eisen interpreteren</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#conformiteitseisen"><bdi class="secno">5.2 </bdi>Conformiteitseisen</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#cc1"><bdi class="secno">5.2.1 </bdi>Conformiteitsniveau</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#cc2"><bdi class="secno">5.2.2 </bdi>Volledige pagina's</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#cc3"><bdi class="secno">5.2.3 </bdi>Volledige processen</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#cc4"><bdi class="secno">5.2.4 </bdi>
+                    Louter door toegankelijkheid ondersteunde manieren om
+                    technologieën te gebruiken
+                  </a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#cc5"><bdi class="secno">5.2.5 </bdi>Niet-interferentie</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#conformiteitsclaims"><bdi class="secno">5.3 </bdi>Conformiteitsclaims (optioneel)</a>
+              <ol class="toc">
+                <li class="tocline">
+                  <a class="tocxref" href="#vereiste-componenten-van-een-conformiteitsclaim"><bdi class="secno">5.3.1 </bdi>Vereiste componenten van een
+                    conformiteitsclaim</a>
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#optionele-componenten-van-een-conformiteitsclaim"><bdi class="secno">5.3.2 </bdi>Optionele componenten van
+                    een conformiteitsclaim</a>
+                </li>
+              </ol>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#verklaring-van-partiele-conformiteit-content-van-derden"><bdi class="secno">5.4 </bdi>Verklaring van partiële
+                conformiteit – Content van derden</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#verklaring-van-partiele-conformiteit-taal"><bdi class="secno">5.5 </bdi>Verklaring van partiële
+                conformiteit – Taal</a>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#verklarende-woordenlijst"><bdi class="secno">6. </bdi>Verklarende woordenlijst</a>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#input-purposes"><bdi class="secno">7. </bdi>Inputdoelen voor componenten van de
+            gebruikersinterface</a>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#dankbetuigingen"><bdi class="secno">A. </bdi>Dankbetuigingen</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#dankbetuiging-voor-actieve-deelnemers"><bdi class="secno">A.1 </bdi> Deelnemers van de
+                <abbr title="Accessibility Guidelines Working Group">AG WG</abbr>
+                die actief zijn bij de ontwikkeling van dit document:
+              </a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#dankbetuiging-voor-eerder-actieve-deelnemers"><bdi class="secno">A.2 </bdi>
+                Andere eerder actieve WCAG WG-deelnemers en andere bijdragers
+                aan WCAG 2.0, WCAG 2.1 of ondersteunende bronnen
+              </a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#mede-mogelijk-gemaakt-door"><bdi class="secno">A.3 </bdi>Mede mogelijk gemaakt door:</a>
+            </li>
+          </ol>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#referenties"><bdi class="secno">B. </bdi>Referenties</a>
+          <ol class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#normatieve-referenties"><bdi class="secno">B.1 </bdi>Normatieve referenties</a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#informatieve-referenties"><bdi class="secno">B.2 </bdi>Informatieve referenties</a>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </nav>
+
+    <section class="informative introductory" id="inleiding">
+      <h2>Inleiding <a class="self-link" aria-label="§" href="#inleiding"></a></h2>
+      <p><em>Dit onderdeel is niet normatief.</em></p>
+
+      <section id="achtergrond-van-wcag-2">
+        <h3 id="x0-1-achtergrond-van-wcag-2">
+          <bdi class="secno">0.1 </bdi>Achtergrond van WCAG 2<a class="self-link" aria-label="§" href="#achtergrond-van-wcag-2"></a>
+        </h3>
+        <p>
+          De Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.1
+          definiëren hoe je webcontent toegankelijker maakt voor mensen met een
+          functiebeperking. Toegankelijkheid betreft een breed scala van
+          functiebeperkingen, waaronder visuele, auditieve, fysieke, spraak-,
+          cognitieve, taal-, leer- en neurologische functiebeperkingen. Hoewel
+          deze richtlijnen een breed scala van aandachtspunten bestrijken, zijn
+          ze niet in staat om in de behoeften van mensen met alle soorten,
+          gradaties en combinaties van functiebeperkingen te voorzien. Deze
+          richtlijnen maken webcontent ook beter bruikbaar voor ouderen, bij wie
+          de vaardigheden door ouderdom veranderen, en verbeteren de
+          bruikbaarheid voor gebruikers in het algemeen.
+        </p>
+        <p>
+          WCAG 2.1 is ontwikkeld door middel van het
+          <a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/"><abbr title="World Wide Web Consortium">W3C</abbr> process</a>
+          in samenwerking met individuen en organisaties wereldwijd, met het
+          doel om een gemeenschappelijke standaard voor toegankelijkheid van
+          webcontent te leveren, die internationaal tegemoetkomt aan de
+          behoeften van individuen, organisaties en overheden. WCAG 2.1 bouwt
+          voort op WCAG 2.0 [<cite><a class="bibref" href="#bib-wcag20" title="Web Content Accessibility Guidelines (WCAG) 2.0" data-link-type="biblio">WCAG20</a></cite>], die op zijn beurt voortbouwt op WCAG 1.0 [<cite><a class="bibref" href="#bib-wai-webcontent" title="Web Content Accessibility Guidelines 1.0" data-link-type="biblio">WAI-WEBCONTENT</a></cite>] en is ontworpen om breed van toepassing te zijn op verschillende
+          webtechnologieën voor nu en in de toekomst en om testbaar te zijn met
+          een combinatie van automatisch testen en menselijke evaluatie. Voor
+          een inleiding tot WCAG, zie het
+          <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a>.
+        </p>
+        <p>
+          Tijdens het definiëren van aanvullende criteria voor cognitieve, taal-
+          en leerbeperkingen werden we geconfronteerd met aanzienlijke
+          uitdagingen, waaronder een korte tijdlijn voor de ontwikkeling en ook
+          het bereiken van consensus over testbaarheid, uitvoerbaarheid, en
+          internationale overwegingen van voorstellen. Werk op dit gebied wordt
+          voortgezet in toekomstige versies van WCAG. We moedigen auteurs aan om
+          te verwijzen naar onze aanvullende documenten over
+          <a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">het verbeteren van de inclusie voor mensen met functiebeperkingen,
+            inclusief leer- en cognitieve beperkingen, slechtziendheid en
+            andere</a>.
+        </p>
+        <p>
+          Webtoegankelijkheid hangt niet alleen af van de toegankelijkheid van
+          content maar ook van de toegankelijkheid van webbrowsers en andere
+          user agents. Authoring tools hebben ook een belangrijke rol in
+          webtoegankelijkheid. Voor een overzicht van hoe deze componenten van
+          webontwikkeling en interactie samenwerken, zie:
+        </p>
+        <ul>
+          <li>
+            <strong>
+              <a href="https://www.w3.org/WAI/fundamentals/components/">Essential Components of Web Accessibility</a>
+            </strong>
+          </li>
+          <li>
+            <strong>
+              <a href="https://www.w3.org/WAI/standards-guidelines/uaag/">User Agent Accessibility Guidelines (UAAG) Overview</a>
+            </strong>
+          </li>
+          <li>
+            <strong>
+              <a href="https://www.w3.org/WAI/standards-guidelines/atag/">Authoring Tool Accessibility Guidelines (ATAG) Overview</a>
+            </strong>
+          </li>
+        </ul>
+      </section>
+
+      <section id="de-gelaagde-structuur-van-wcag-2">
+        <h3 id="x0-2-de-gelaagde-structuur-van-wcag-2">
+          <bdi class="secno">0.2 </bdi>De gelaagde structuur van WCAG 2<a class="self-link" aria-label="§" href="#de-gelaagde-structuur-van-wcag-2"></a>
+        </h3>
+        <p>
+          De personen en organisaties die WCAG gebruiken zijn sterk gevarieerd
+          en omvatten webontwerpers, webontwikkelaars, beleidsmakers, inkopers,
+          leraren en studenten. Om aan de verschillende behoeften van deze
+          groepen te voldoen, worden verschillende lagen van advies geleverd,
+          waaronder globale
+          <em>principes</em>, algemene <em>richtlijnen</em>, toetsbare
+          <em>succescriteria</em> en een uitgebreide verzameling
+          <em>afdoende technieken</em>, <em>aanbevolen technieken</em> en
+          <em>gedocumenteerde gangbare fouten</em> met voorbeelden, links naar
+          hulpmiddelen en broncode.
+        </p>
+        <ul>
+          <li>
+            <p>
+              <strong>Principes</strong> - Bovenaan staan vier principes die het
+              fundament voor webtoegankelijkheid vormen:
+              <em>waarneembaar, bedienbaar, begrijpelijk en robuust</em>.
+              <a href="https://www.w3.org/WAI/WCAG21/Understanding/intro#understanding-the-four-principles-of-accessibility">Understanding the Four Principles of Accessibility</a>.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Richtlijnen</strong> - Onder de principes vallen
+              richtlijnen. De 13 richtlijnen vormen de hoofddoelen die auteurs
+              moeten nastreven om content toegankelijker te maken voor
+              gebruikers met verschillende functiebeperkingen. De richtlijnen
+              zijn niet toetsbaar, maar leveren het kader en de algemene doelen
+              om auteurs te helpen de succescriteria te begrijpen en de
+              technieken beter te implementeren.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Succescriteria</strong> - Elke richtlijn is voorzien van
+              toetsbare succescriteria, zodat WCAG 2.0 gebruikt kan worden waar
+              vereisten en toetsen op conformiteit noodzakelijk zijn, zoals bij
+              het specificeren van het ontwerp, inkoop, regulering en
+              contractuele overeenkomsten. Om aan de behoeften van verschillende
+              groepen en verschillende situaties te voldoen, zijn drie niveaus
+              van conformiteit gedefinieerd: A (laagst), AA en AAA (hoogst).
+              Aanvullende informatie over WCAG-niveaus is te vinden in
+              <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#levels">Understanding Levels of Conformance</a>.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Afdoende en aanbevolen technieken</strong> - Voor elk van
+              de <em>richtlijnen</em> en <em>succescriteria</em> in het WCAG 2.0
+              document zelf heeft de Werkgroep ook een breed scala van
+              <em>technieken</em> gedocumenteerd. De technieken zijn informatief
+              en vallen onder twee categorieën: zij die <em>afdoende</em> zijn
+              om aan de succescriteria te voldoen en zij die
+              <em>aanbevolen</em> zijn. De aanbevolen technieken gaan verder dan
+              wat vanuit de individuele succescriteria wordt geëist en maken het
+              auteurs mogelijk zich beter aan de richtlijnen te houden. Sommige
+              aanbevolen technieken richten zich op toegankelijkheidsbarrières
+              die niet afgedekt worden door de testbare succescriteria. Waar
+              gangbare fouten bekend zijn, worden die ook gedocumenteerd. Zie
+              ook
+              <a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-techniques">Sufficient and Advisory Techniques in Understanding WCAG 2.0</a>.
+            </p>
+          </li>
+        </ul>
+        <p>
+          De gelaagde adviezen (principes, richtlijnen, succescriteria en
+          afdoende en aanbevolen technieken) leveren samen een compleet advies
+          over het toegankelijk maken van content. Auteurs worden aangemoedigd
+          om alle lagen te bekijken en toe te passen indien mogelijk, met
+          inbegrip van de aanbevolen technieken, om zich optimaal te richten op
+          de behoeften van een zo groot mogelijke groep gebruikers.
+        </p>
+        <p>
+          Bedenk dat zelfs content die conformeert aan het hoogste niveau (AAA)
+          niet toegankelijk zal zijn voor individuen met alle soorten, gradaties
+          of combinaties van functiebeperkingen, in het bijzonder in de
+          cognitieve gebieden van taal en leren. Auteurs worden aangemoedigd om
+          het volledige scala van technieken, inclusief de aanbevolen technieken
+          te overwegen, en ook om advies te vragen wat de huidige beste praktijk
+          is om webcontent voor deze doelgroep zo toegankelijk mogelijk te
+          maken.
+          <a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-metadata">Metadata</a>
+          kan gebruikers helpen om content te vinden die het best aansluit bij
+          hun behoeften.
+        </p>
+      </section>
+
+      <section id="documenten-die-wcag-2-1-ondersteunen">
+        <h3 id="x0-3-documenten-die-wcag-2-1-ondersteunen">
+          <bdi class="secno">0.3 </bdi>Documenten die WCAG 2.1 ondersteunen<a class="self-link" aria-label="§" href="#documenten-die-wcag-2-1-ondersteunen"></a>
+        </h3>
+        <p>
+          Het WCAG 2.0 document is ontworpen om tegemoet te komen aan de
+          behoeften van degenen die een stabiele technische standaard nodig
+          hebben waarnaar verwezen kan worden. Andere documenten, zogeheten
+          ondersteunende documenten, zijn gebaseerd op het WCAG 2.0 document en
+          richten zich op andere belangrijke doelen, inclusief de mogelijkheid
+          om geüpdatet te worden zodat beschreven kan worden hoe WCAG bij nieuwe
+          technologieën zou worden toegepast. Ondersteunende documenten bestaan
+          uit:
+        </p>
+        <ol class="enumar">
+          <li>
+            <p>
+              <strong>
+                <a href="https://www.w3.org/WAI/WCAG21/quickref/">How to Meet WCAG 2.1</a>
+              </strong>
+              - Een op maat aan te passen snelle verwijzing naar WCAG 2.1; deze
+              omvat alle richtlijnen, succescriteria en technieken voor auteurs
+              om te gebruiken als ze webcontent ontwikkelen en evalueren. Het
+              omvat content uit WCAG 2.0 en WCAG 2.1 en er kunnen diverse
+              filters worden ingesteld, zodat auteurs zich kunnen focussen op
+              relevante content.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                <a href="https://www.w3.org/WAI/WCAG21/Understanding/">Understanding WCAG 2.1</a>
+              </strong>
+              - Een gids om WCAG 2.1 te begrijpen en te implementeren. Er is in
+              WCAG 2.1 een kort "uitleg"-document voor elke richtlijn en voor
+              elk succescriterium en uitleg van belangrijke onderwerpen.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                <a href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG 2.1</a>
+              </strong>
+              - Een verzameling technieken en algemeen gangbare fouten, elk in
+              een apart document dat een beschrijving, voorbeelden, codering en
+              tests bevat.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                <a href="https://www.w3.org/WAI/standards-guidelines/wcag/docs/">The WCAG Documents</a>
+              </strong>
+              - Een diagram en beschrijving van hoe de technische documenten
+              zich tot elkaar verhouden en verbonden zijn.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                <a href="x">What's New in WCAG 2.2</a>
+              </strong>
+              - Introduceert de nieuwe succescriteria met citaten van persona’s 
+              die de toegankelijkheidsproblemen illustreren.
+            </p>
+          </li>
+        </ol>
+        <p>
+          Zie
+          <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a>
+          voor een beschrijving van het WCAG 2.0 hulpmateriaal, waaronder
+          leermateriaal gerelateerd aan WCAG 2. Aanvullende bronnen die
+          onderwerpen behandelen zoals de businesscase voor webtoegankelijkheid,
+          het plannen van de implementatie om de toegankelijkheid van websites
+          te verbeteren en toegankelijkheidsbeleid, zijn te vinden in
+          <a href="https://www.w3.org/WAI/Resources/Overview">WAI Resources</a>.
+        </p>
+      </section>
+
+      <section id="eisen-aan-wcag-2-1">
+        <h3 id="x0-4-eisen-aan-wcag-2-1">
+          <bdi class="secno">0.4 </bdi>Eisen aan WCAG 2.2<a class="self-link" aria-label="§" href="#eisen-aan-wcag-2-1"></a>
+        </h3>
+        <p>
+          WCAG 2.2 voldoet aan een reeks
+          <a href="https://w3c.github.io/wcag21/requirements/">eisen die aan WCAG 2.2 worden gesteld</a>. Deze eisen zijn op hun beurt afgeleid van eerdere versies
+          van WCAG 2. De gestelde
+          eisen zorgen voor het gestructureerde kader voor de richtlijnen en
+          garanderen compatibiliteit met eerdere versies. De Werkgroep heeft ook
+          minder formele acceptatiecriteria voor de succescriteria gebruikt,
+          zodat de stijl en kwaliteit van de succescriteria overeenkomen met die
+          van de criteria in WCAG 2.0. Deze eisen vormden een beperking voor wat
+          kon worden opgenomen in WCAG 2.2. Deze beperking is belangrijk omdat 
+          die ervoor zorgt dat er meerdere versies (dot-release) van WCAG 2 mogelijk zijn.
+        </p>
+      </section>
+
+      <section id="vergelijking-met-wcag-2-0">
+        <h3 id="x0-5-vergelijking-met-wcag-2-0">
+          <bdi class="secno">0.5 </bdi>Vergelijking met WCAG 2.1<a class="self-link" aria-label="§" href="#vergelijking-met-wcag-2-0"></a>
+        </h3>
+        <p>
+          WCAG 2.1 werd gestart met het doel de aanbevelingen over
+          toegankelijkheid te verbeteren voor drie grote groepen: gebruikers met
+          een leer- of cognitieve functiebeperking, slechtzienden en gebruikers
+          met functiebeperkingen bij het gebruik van mobiele apparaten. Er
+          werden veel voorstellen gedaan en geëvalueerd en de Werkgroep heeft
+          uiteindelijk een aantal van deze voorstellen uitgewerkt. De
+          definitieve succescriteria in deze versie zijn gebaseerd op de
+          structurele eisen uit WCAG 2.0, de duidelijkheid en impact van de
+          voorstellen en de tijdlijn. Volgens de Werkgroep zijn de aanbevelingen
+          voor toegankelijkheid van webcontent voor al deze gebieden in WCAG 2.1
+          aanzienlijk verbeterd, maar de Werkgroep benadrukt dat deze
+          richtlijnen niet in alle behoeften van gebruikers voorzien.
+        </p>
+        <p>
+          WCAG 2.1 bouwt voort op en is compatibel met de voorgaande versie WCAG
+          2.0. Dit betekent dat webpagina's die conformeren aan WCAG 2.1 ook
+          conformeren aan WCAG 2.0. Er zijn eisen toegevoegd die voortbouwen op 2.1 en 2.0. 
+          WCAG 2.2 heeft 1 succescriterium verwijderd, namelijk 4.1.1 Parsen. Auteurs die 
+          beleidsmatig verplicht zijn om te voldoen aan WCAG 2.0 of 2.1, kunnen hun content 
+          bijwerken naar WCAG 2.2, maar moeten mogelijk blijven testen op en rapporteren over 
+          4.1.1. Auteurs die meer dan 1 versie van de richtlijnen volgen, moeten rekening houden 
+          met de hierna volgende aanvullingen.
+        </p>
+
+        <section id="nieuwe-kenmerken-in-wcag-2-1">
+          <h4 id="x0-5-1-nieuwe-kenmerken-in-wcag-2-1">
+            <bdi class="secno">0.5.1 </bdi>Nieuwe kenmerken in WCAG 2.2<a class="self-link" aria-label="§" href="#nieuwe-kenmerken-in-wcag-2-1"></a>
+          </h4>
+          <p>
+            WCAG 2.2 bouwt voort op WCAG 2.1 met de toevoeging van nieuwe
+            succescriteria en hun definities, richtlijnen om de toevoegingen te
+            structureren, en een aantal toevoegingen aan het hoofdstuk
+            Conformiteit. Deze aanpak met aanvullingen helpt om duidelijk te
+            maken dat sites die conformeren aan WCAG 2.2 ook conformeren aan
+            WCAG 2.1 en daarmee voldoen aan de specifieke
+            conformiteitsverplichtingen van WCAG 2.0. De Accessibility
+            Guidelines Werkgroep beveelt aan dat sites WCAG 2.1 als nieuw
+            conformiteitsniveau gebruiken, zelfs wanneer formele verplichtingen
+            verwijzen naar WCAG 2.0, zodat zij een verbeterde toegankelijkheid
+            kunnen bieden en inspelen op toekomstige veranderingen in beleid.
+          </p>
+          <p>
+            De volgende succescriteria zijn toegevoegd aan WCAG 2.2:
+          </p>
+          <ul>
+            <li>
+              2.4.11
+              <a href="#focus-not-obscured-minimum">Focus niet bedekt (minimum)</a>
+              (AA)
+            </li>
+            <li>
+              2.4.12
+              <a href="#focus-not-obscured-enhanced">Focus niet bedekt (uitgebreid)</a>
+              (AAA)
+            </li>
+            <li>
+              2.4.13
+              <a href="#focus-appearance">Focusweergave</a>
+              (AAA)
+            </li>
+            <li>
+              2.5.7
+              <a href="#dragging-movements">Sleepbewegingen</a>
+              (AA)
+            </li>
+            <li>
+              2.5.8
+              <a href="#target-size-minimum">Grootte van het aanwijsgebied (minimum)</a>
+              (AA)
+            </li>
+            <li>
+              3.2.6
+              <a href="#consistent-help">Consistente hulp</a>
+              (A)
+            </li>
+            <li>
+              3.3.7
+              <a href="#redundant-entry">Overbodige invoer</a>
+              (A)
+            </li>
+            <li>
+              3.3.8
+              <a href="#accessible-authentication-minimum">Toegankelijke authenticatie (minimum)</a>
+              (AA)
+            </li>
+            <li>
+              3.3.9
+              <a href="#accessible-authentication-enhanced">Toegankelijke authenticatie (uitgebreid)</a>
+              (AAA)
+            </li>
+          </ul>
+          <p>
+            De nieuwe succescriteria kunnen verwijzen naar nieuwe termen die 
+            ook zijn toegevoegd aan de verklarende woordenlijst en deel uitmaken 
+            van de normatieve vereisten van de succescriteria. 
+          </p>
+          <p>
+            WCAG 2.2 introduceert ook nieuwe secties met details over aspecten van 
+            de specificatie die van invloed kunnen zijn op privacy en security. 
+          </p>
+        </section>
+
+        <section id="nummering-in-wcag-2-1">
+          <h4 id="x0-5-2-nummering-in-wcag-2-1">
+            <bdi class="secno">0.5.2 </bdi>Nummering in WCAG 2.1<a class="self-link" aria-label="§" href="#nummering-in-wcag-2-1"></a>
+          </h4>
+          <p>
+            Om verwarring te voorkomen bij gebruikers die veel waarde hechten
+            aan achterwaartse compatibiliteit met WCAG 2.0, zijn de nieuwe
+            succescriteria in WCAG 2.1 aan het einde van de reeks succescriteria
+            van de betreffende richtlijn toegevoegd. Hierdoor hoeft de
+            paragraafnummering van de succescriteria in WCAG 2.0 niet te worden
+            aangepast. Dat zou wel noodzakelijk zijn geweest als de nieuwe
+            succescriteria tussen de bestaande succescriteria waren toegevoegd.
+            Het gevolg is wel dat de succescriteria van elke richtlijn niet meer
+            per conformiteitsniveau zijn gegroepeerd. De volgorde van de
+            succescriteria van elke richtlijn geeft geen informatie over het
+            conformiteitsniveau; dit kan alleen worden afgeleid uit de
+            indicaties (A / AA / AAA) behorende bij het betreffende
+            succescriterium. De
+            <a href="https://www.w3.org/WAI/WCAG21/quickref/">Quick Reference naar WCAG 2.1</a>
+            beschrijft manieren om succescriteria gegroepeerd per
+            conformiteitsniveau te bekijken samen met andere filter- en
+            sorteermogelijkheden.
+          </p>
+        </section>
+
+        <section id="conformiteit-met-wcag-2-1">
+          <h4 id="x0-5-3-conformiteit-met-wcag-2-1">
+            <bdi class="secno">0.5.3 </bdi>Conformiteit met WCAG 2.1<a class="self-link" aria-label="§" href="#conformiteit-met-wcag-2-1"></a>
+          </h4>
+          <p>
+            WCAG 2.1 gebruikt hetzelfde conformiteitsmodel als WCAG 2.0, maar
+            met een aantal toevoegingen. Dit model is beschreven in het
+            hoofdstuk
+            <a href="#conformiteit">Conformiteit</a>. Het is de bedoeling dat
+            sites die conformeren aan WCAG 2.1 ook conformeren aan WCAG 2.0. Dit
+            betekent dat ze voldoen aan de eisen in alle beleidsmaatregelen die
+            verwijzen naar WCAG 2.0, terwijl ook beter wordt voldaan aan de
+            behoeften van gebruikers van het huidige web.
+          </p>
+        </section>
+      </section>
+
+      <section id="latere-versies-van-de-richtlijnen-voor-toegankelijkheid">
+        <h3 id="x0-6-latere-versies-van-de-richtlijnen-voor-toegankelijkheid">
+          <bdi class="secno">0.6 </bdi>Latere versies van de Richtlijnen voor
+          Toegankelijkheid<a class="self-link" aria-label="§" href="#latere-versies-van-de-richtlijnen-voor-toegankelijkheid"></a>
+        </h3>
+
+        <p>
+          Naast WCAG 2.1 ontwikkelt de Accessibility Guidelines Werkgroep een
+          nieuwe hoofdversie van de richtlijnen voor toegankelijkheid. Het
+          verwachte resultaat van dit werk is een meer substantiële
+          herstructurering van de toegankelijkheidsrichtlijnen dan realistisch
+          zou zijn voor een dot-release van WCAG 2. Er wordt een op
+          onderzoeksresultaten en gebruikers gerichte ontwerpmethode gevolgd om
+          het meest effectieve en flexibele resultaat te creëren, inclusief de
+          rollen van <em>content authoring</em>, <em>user agent support</em> en
+          <em>authoring tool support</em>. Omdat het gaat om een meerjarige
+          inspanning, is WCAG 2.1 nodig als interim maatregel. WCAG 2.1 omvat
+          bijgewerkte aanbevelingen voor toegankelijkheid die een weerspiegeling
+          zijn van de veranderingen op het web sinds de publicatie van WCAG 2.0.
+          De Werkgroep kan op korte termijn meer interim-versies maken,
+          beginnend met WCAG 2.2, om extra ondersteuning te bieden terwijl de
+          hoofdversie wordt voltooid.
+        </p>
+      </section>
+    </section>
+
+    <section class="principle" id="waarneembaar">
+      <h2 id="x1-waarneembaar">
+        <span>Principe </span><bdi class="secno">1. </bdi>Waarneembaar<a class="self-link" aria-label="§" href="#waarneembaar"></a>
+      </h2>
+      <p>
+        Informatie en componenten van de gebruikersinterface moeten toonbaar
+        zijn aan gebruikers op voor hen waarneembare wijze.
+      </p>
+
+      <section class="guideline" id="tekstalternatieven">
+        <h3 id="x1-1-tekstalternatieven">
+          <span>Richtlijn </span><bdi class="secno">1.1 </bdi>Tekstalternatieven<a class="self-link" aria-label="§" href="#tekstalternatieven"></a>
+        </h3>
+        <p>
+          Lever tekstalternatieven voor alle niet-tekstuele content, zodat die
+          veranderd kan worden in andere vormen die mensen nodig hebben, zoals
+          grote letters, braille, spraak, symbolen of eenvoudigere taal.
+        </p>
+
+        <section class="sc" data-alt-id="non-text-content" id="niet-tekstuele-content">
+          <h4 id="x1-1-1-niet-tekstuele-content">
+            <span>Succescriterium </span><bdi class="secno">1.1.1 </bdi>Niet-tekstuele content<a class="self-link" aria-label="§" href="#niet-tekstuele-content"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html">Niet-tekstuele content begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-content">Hoe te voldoen aan Niet-tekstuele content</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Alle
+            <a href="#dfn-niet-tekstuele-content" class="internalDFN" data-link-type="dfn">niet-tekstuele content</a>
+            die aan de gebruiker wordt gepresenteerd, heeft een
+            <a href="#dfn-tekstalternatief" class="internalDFN" data-link-type="dfn">tekstalternatief</a>
+            dat een gelijkwaardig doel dient, behalve voor de hierna vermelde
+            situaties.
+          </p>
+
+          <dl>
+            <dt>Bedieningselementen, invoer</dt>
+            <dd>
+              <p>
+                Als niet-tekstuele content een bedieningselement is of
+                gebruikersinvoer accepteert, dan heeft deze een
+                <a href="#dfn-naam" class="internalDFN" data-link-type="dfn">naam</a>
+                die het doel ervan beschrijft. (We verwijzen naar
+                <a href="#naam-rol-waarde">succescriterium 4.1.2</a> voor
+                aanvullende eisen ten aanzien van bedieningselementen en content
+                die gebruikersinvoer accepteren.)
+              </p>
+            </dd>
+
+            <dt>Op tijd gebaseerde media</dt>
+            <dd>
+              <p>
+                Als niet-tekstuele content op tijd gebaseerde media is, dan
+                leveren tekstalternatieven ten minste een beschrijving van de
+                niet-tekstuele content. (We verwijzen naar
+                <a href="#op-tijd-gebaseerde-media">Richtlijn 1.2</a> voor
+                aanvullende eisen ten aanzien van media.)
+              </p>
+            </dd>
+
+            <dt>Test</dt>
+            <dd>
+              <p>
+                Als niet-tekstuele content een test of oefening is die, als ze
+                door middel van
+                <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+                gepresenteerd wordt onjuist zou zijn, dan leveren
+                tekstalternatieven ten minste een beschrijving van de
+                niet-tekstuele content.
+              </p>
+            </dd>
+
+            <dt>Zintuiglijk</dt>
+            <dd>
+              <p>
+                Als niet-tekstuele content primair is bedoeld om een
+                <a href="#dfn-specifieke-zintuiglijke-ervaring" class="internalDFN" data-link-type="dfn">specifieke zintuiglijke ervaring</a>
+                te creëren, dan leveren tekstalternatieven ten minste een
+                beschrijving van de niet-tekstuele content.
+              </p>
+            </dd>
+
+            <dt>
+              <a href="#dfn-captcha" class="internalDFN" data-link-type="dfn">CAPTCHA</a>
+            </dt>
+            <dd>
+              <p>
+                Als het doel van niet-tekstuele content is om te bevestigen dat
+                content wordt gebruikt door een persoon in plaats van een
+                computer, dan worden tekstalternatieven geleverd die het doel
+                van de niet-tekstuele content identificeren en beschrijven. En
+                er worden alternatieve vormen van CAPTCHA aangeboden
+                gebruikmakend van uitvoermodes voor verschillende soorten van
+                zintuiglijke perceptie om tegemoet te komen aan verschillende
+                functiebeperkingen.
+              </p>
+            </dd>
+
+            <dt>Decoratie, opmaak, onzichtbaar</dt>
+            <dd>
+              <p>
+                Als niet-tekstuele content
+                <a href="#dfn-puur-decoratief" class="internalDFN" data-link-type="dfn">puur decoratief</a>
+                is, slechts voor visuele opmaak wordt gebruikt, of niet aan
+                gebruikers wordt gerepresenteerd, dan wordt het op zo'n manier
+                geïmplementeerd dat het genegeerd kan worden door
+                <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologie</a>.
+              </p>
+            </dd>
+          </dl>
+        </section>
+      </section>
+
+      <section class="guideline" id="op-tijd-gebaseerde-media">
+        <h3 id="x1-2-op-tijd-gebaseerde-media">
+          <span>Richtlijn </span><bdi class="secno">1.2 </bdi>Op tijd gebaseerde
+          media<a class="self-link" aria-label="§" href="#op-tijd-gebaseerde-media"></a>
+        </h3>
+        <p>
+          Lever alternatieven voor op tijd gebaseerde media.
+        </p>
+
+        <section class="sc" data-alt-id="audio-only-and-video-only-prerecorded" id="louter-geluid-en-louter-videobeeld-vooraf-opgenomen">
+          <h4 id="x1-2-1-louter-geluid-en-louter-videobeeld-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.1 </bdi>Louter-geluid en louter-videobeeld
+            (vooraf opgenomen)<a class="self-link" aria-label="§" href="#louter-geluid-en-louter-videobeeld-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html">Louter-geluid en louter-videobeeld (vooraf opgenomen)
+              begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-only-and-video-only-prerecorded">Hoe te voldoen aan Louter-geluid en louter-videobeeld (vooraf
+              opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Voor media met
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-louter-geluid" class="internalDFN" data-link-type="dfn">louter-geluid</a>
+            en vooraf opgenomen
+            <a href="#dfn-louter-videobeeld" class="internalDFN" data-link-type="dfn">louter-videobeeld</a>
+            is het volgende waar, behalve als de audio of video een
+            <a href="#dfn-media-alternatief-voor-tekst" class="internalDFN" data-link-type="dfn">media-alternatief voor tekst</a>
+            is en duidelijk als zodanig is gelabeld:
+          </p>
+
+          <dl>
+            <dt>Vooraf opgenomen louter-geluid</dt>
+            <dd>
+              <p>
+                Er wordt een
+                <a href="#dfn-alternatief-geleverd-voor-op-tijd-gebaseerde-media" class="internalDFN" data-link-type="dfn">alternatief geleverd voor op tijd gebaseerde media</a>
+                dat equivalente informatie geeft voor vooraf opgenomen
+                louter-geluid content.
+              </p>
+            </dd>
+
+            <dt>Vooraf opgenomen louter-videobeeld</dt>
+            <dd>
+              <p>
+                Er wordt een alternatief geleverd voor op tijd gebaseerde media
+                of een geluidsspoor dat equivalente informatie geeft voor vooraf
+                opgenomen louter-videobeeld content.
+              </p>
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc" data-alt-id="captions-prerecorded" id="ondertitels-voor-doven-en-slechthorenden-vooraf-opgenomen">
+          <h4 id="x1-2-2-ondertitels-voor-doven-en-slechthorenden-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.2 </bdi>Ondertitels voor doven en
+            slechthorenden (vooraf opgenomen)<a class="self-link" aria-label="§" href="#ondertitels-voor-doven-en-slechthorenden-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html">Ondertitels voor doven en slechthorenden (vooraf opgenomen)
+              begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#captions-prerecorded">Hoe te voldoen aan Ondertitels voor doven en slechthorenden
+              (vooraf opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Er worden
+            <a href="#dfn-ondertitels" class="internalDFN" data-link-type="dfn">ondertitels</a>
+            voor doven en slechthorenden geleverd voor alle
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>content in
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>, behalve als het mediabestand een
+            <a href="#dfn-media-alternatief-voor-tekst" class="internalDFN" data-link-type="dfn">media-alternatief voor tekst</a>
+            is en duidelijk als zodanig is gelabeld.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="audio-description-or-media-alternative-prerecorded" id="audiodescriptie-of-media-alternatief-vooraf-opgenomen">
+          <h4 id="x1-2-3-audiodescriptie-of-media-alternatief-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.3 </bdi>Audiodescriptie of media-alternatief
+            (vooraf opgenomen)<a class="self-link" aria-label="§" href="#audiodescriptie-of-media-alternatief-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html">Audiodescriptie of media-alternatief (vooraf opgenomen)
+              begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-description-or-media-alternative-prerecorded">Hoe te voldoen aan Audiodescriptie of media-alternatief (vooraf
+              opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Er wordt een
+            <a href="#dfn-alternatief-geleverd-voor-op-tijd-gebaseerde-media" class="internalDFN" data-link-type="dfn">alternatief geleverd voor op tijd gebaseerde media</a>
+            of
+            <a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">audiodescriptie</a>
+            van de
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>content geleverd voor
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>, behalve als het mediabestand een
+            <a href="#dfn-media-alternatief-voor-tekst" class="internalDFN" data-link-type="dfn">media-alternatief voor tekst</a>
+            is en duidelijk als zodanig is gelabeld.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="captions-live" id="ondertitels-voor-doven-en-slechthorenden-live">
+          <h4 id="x1-2-4-ondertitels-voor-doven-en-slechthorenden-live">
+            <span>Succescriterium </span><bdi class="secno">1.2.4 </bdi>Ondertitels voor doven en
+            slechthorenden (live)<a class="self-link" aria-label="§" href="#ondertitels-voor-doven-en-slechthorenden-live"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html">Ondertitels voor doven en slechthorenden (live) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#captions-live">Hoe te voldoen aan Ondertitels voor doven en slechthorenden
+              (live)</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Er worden
+            <a href="#dfn-ondertitels" class="internalDFN" data-link-type="dfn">ondertitels</a>
+            voor doven en slechthorenden geleverd voor alle
+            <a href="#dfn-live" class="internalDFN" data-link-type="dfn">live</a>
+            <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>content in
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="audio-description-prerecorded" id="audiodescriptie-vooraf-opgenomen">
+          <h4 id="x1-2-5-audiodescriptie-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.5 </bdi>Audiodescriptie (vooraf opgenomen)<a class="self-link" aria-label="§" href="#audiodescriptie-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded.html">Audiodescriptie (vooraf opgenomen) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-description-prerecorded">Hoe te voldoen aan Audiodescriptie (vooraf opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Er wordt een
+            <a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">audiodescriptie</a>
+            geleverd voor alle
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>content in
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="sign-language-prerecorded" id="gebarentaal-vooraf-opgenomen">
+          <h4 id="x1-2-6-gebarentaal-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.6 </bdi>Gebarentaal (vooraf opgenomen)<a class="self-link" aria-label="§" href="#gebarentaal-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded.html">Gebarentaal (vooraf opgenomen) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#sign-language-prerecorded">Hoe te voldoen aan Gebarentaal (vooraf opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er wordt een
+            <a href="#dfn-gebarentaalvertolking" class="internalDFN" data-link-type="dfn">gebarentaalvertolking</a>
+            geleverd voor alle
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>content in
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="extended-audio-description-prerecorded" id="verlengde-audiodescriptie-vooraf-opgenomen">
+          <h4 id="x1-2-7-verlengde-audiodescriptie-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.7 </bdi>Verlengde audiodescriptie (vooraf
+            opgenomen)<a class="self-link" aria-label="§" href="#verlengde-audiodescriptie-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded.html">Verlengde audiodescriptie (vooraf opgenomen) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#extended-audio-description-prerecorded">Hoe te voldoen aan Verlengde audiodescriptie (vooraf
+              opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Waar pauzes in voorgrondgeluid onvoldoende zijn om
+            <a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">audiodescripties</a>
+            toe te passen om de boodschap van de video over te brengen, wordt
+            een
+            <a href="#dfn-verlengde-audiodescriptie" class="internalDFN" data-link-type="dfn">verlengde audiodescriptie</a>
+            geleverd voor alle
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>content in
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="media-alternative-prerecorded" id="media-alternatief-vooraf-opgenomen">
+          <h4 id="x1-2-8-media-alternatief-vooraf-opgenomen">
+            <span>Succescriterium </span><bdi class="secno">1.2.8 </bdi>Media-alternatief (vooraf
+            opgenomen)<a class="self-link" aria-label="§" href="#media-alternatief-vooraf-opgenomen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded.html">Media-alternatief (vooraf opgenomen) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#media-alternative-prerecorded">Hoe te voldoen aan Media-alternatief (vooraf opgenomen)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er wordt een
+            <a href="#dfn-alternatief-geleverd-voor-op-tijd-gebaseerde-media" class="internalDFN" data-link-type="dfn">alternatief geleverd voor op tijd gebaseerde media</a>
+            voor alle
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>
+            en voor alle vooraf opgenomen
+            <a href="#dfn-louter-videobeeld" class="internalDFN" data-link-type="dfn">louter-videobeeld</a>
+            media.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="audio-only-live" id="louter-geluid-live">
+          <h4 id="x1-2-9-louter-geluid-live">
+            <span>Succescriterium </span><bdi class="secno">1.2.9 </bdi>Louter-geluid (live)<a class="self-link" aria-label="§" href="#louter-geluid-live"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/audio-only-live.html">Louter-geluid (live) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-only-live">Hoe te voldoen aan Louter-geluid (live)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er wordt een
+            <a href="#dfn-alternatief-geleverd-voor-op-tijd-gebaseerde-media" class="internalDFN" data-link-type="dfn">alternatief geleverd voor op tijd gebaseerde media</a>
+            dat equivalente informatie presenteert voor
+            <a href="#dfn-live" class="internalDFN" data-link-type="dfn">live</a>
+            <a href="#dfn-louter-geluid" class="internalDFN" data-link-type="dfn">louter-geluid</a>
+            content.
+          </p>
+        </section>
+      </section>
+
+      <section class="guideline" id="aanpasbaar">
+        <h3 id="x1-3-aanpasbaar">
+          <span>Richtlijn </span><bdi class="secno">1.3 </bdi>Aanpasbaar<a class="self-link" aria-label="§" href="#aanpasbaar"></a>
+        </h3>
+        <p>
+          Creëer content die op verschillende manieren gepresenteerd kan worden
+          (bijvoorbeeld eenvoudiger lay-out) zonder verlies van informatie of
+          structuur.
+        </p>
+
+        <section class="sc" data-alt-id="info-and-relationships" id="info-en-relaties">
+          <h4 id="x1-3-1-info-en-relaties">
+            <span>Succescriterium </span><bdi class="secno">1.3.1 </bdi>Info en
+            relaties<a class="self-link" aria-label="§" href="#info-en-relaties"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html">Info en relaties begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships">Hoe te voldoen aan Info en relaties</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Informatie,
+            <a href="#dfn-structuur" class="internalDFN" data-link-type="dfn">structuur</a>
+            en
+            <a href="#dfn-relaties" class="internalDFN" data-link-type="dfn">relaties</a>
+            overgebracht door
+            <a href="#dfn-presentatie" class="internalDFN" data-link-type="dfn">presentatie</a>
+            kunnen
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden of zijn beschikbaar in tekst.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="meaningful-sequence" id="betekenisvolle-volgorde">
+          <h4 id="x1-3-2-betekenisvolle-volgorde">
+            <span>Succescriterium </span><bdi class="secno">1.3.2 </bdi>Betekenisvolle volgorde<a class="self-link" aria-label="§" href="#betekenisvolle-volgorde"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html">Betekenisvolle volgorde begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#meaningful-sequence">Hoe te voldoen aan Betekenisvolle volgorde</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als de volgorde waarin content wordt gepresenteerd van invloed is op
+            zijn betekenis, kan een
+            <a href="#dfn-correcte-leesvolgorde" class="internalDFN" data-link-type="dfn">correcte leesvolgorde</a>
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="sensory-characteristics" id="zintuiglijke-eigenschappen">
+          <h4 id="x1-3-3-zintuiglijke-eigenschappen">
+            <span>Succescriterium </span><bdi class="secno">1.3.3 </bdi>Zintuiglijke eigenschappen<a class="self-link" aria-label="§" href="#zintuiglijke-eigenschappen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html">Zintuiglijke eigenschappen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#sensory-characteristics">Hoe te voldoen aan Zintuiglijke eigenschappen</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Instructies die geleverd worden om content te begrijpen en te
+            bedienen zijn niet alleen afhankelijk van zintuiglijke eigenschappen
+            van componenten zoals vorm, kleur, omvang, visuele locatie,
+            oriëntatie of geluid.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID">
+
+            <div role="heading" class="note-title marker" id="h-note" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Voor eisen met betrekking tot kleur zie
+              <a href="#zintuiglijke-eigenschappen">Richtlijn 1.4</a>.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="orientation" id="weergavestand">
+          <h4 id="x1-3-4-weergavestand">
+            <span>Succescriterium </span><bdi class="secno">1.3.4 </bdi>Weergavestand<a class="self-link" aria-label="§" href="#weergavestand"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/orientation.html">Weergavestand begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#orientation">Hoe te voldoen aan Weergavestand</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            De content beperkt de weergave en bediening niet tot een enkele
+            presentatie-oriëntatie, zoals staand of liggend, tenzij een
+            specifieke presentatie-oriëntatie
+            <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+            is.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-0">
+
+            <div role="heading" class="note-title marker" id="h-note-0" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Voorbeelden waarbij een specifieke presentatie-oriëntatie
+              essentieel kan zijn: een acceptgiro, een piano applicatie, dia’s
+              voor een projector of televisiescherm, of Virtual Reality waarbij
+              de weergavestand van de content niet noodzakelijkerwijs beperkt is
+              tot staand of liggend.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="identify-input-purpose" id="identificeer-het-doel-van-de-input">
+          <h4 id="x1-3-5-identificeer-het-doel-van-de-input">
+            <span>Succescriterium </span><bdi class="secno">1.3.5 </bdi>Identificeer het doel van de input<a class="self-link" aria-label="§" href="#identificeer-het-doel-van-de-input"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html">Identificeer het doel van de input begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#identify-input-purpose">Hoe te voldoen aan Identificeer het doel van de input</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Het doel van elk invoerveld waarmee informatie van de gebruiker
+            wordt verzameld, kan
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden wanneer:
+          </p>
+
+          <ul>
+            <li>
+              Het invoerveld een doel dient dat is geïdentificeerd in de
+              <a href="#input-purposes">paragraaf Inputdoelen voor Componenten van de
+                Gebruikersinterface</a>; en
+            </li>
+            <li>
+              De content wordt geïmplementeerd met behulp van technologieën die
+              ondersteuning bieden bij het identificeren van de verwachte
+              betekenis van formulier-invoergegevens.
+            </li>
+          </ul>
+        </section>
+
+        <section class="sc new" data-alt-id="identify-purpose" id="identificeer-het-doel">
+          <h4 id="x1-3-6-identificeer-het-doel">
+            <span>Succescriterium </span><bdi class="secno">1.3.6 </bdi>Identificeer het doel<a class="self-link" aria-label="§" href="#identificeer-het-doel"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/identify-purpose.html">Identificeer het doel begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#identify-purpose">Hoe te voldoen aan Identificeer het doel</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            In content die is geïmplementeerd met opmaaktalen, kan het doel van
+            de
+            <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>, pictogrammen en
+            <a href="#dfn-regions" class="internalDFN" data-link-type="dfn">regio's</a>
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden.
+          </p>
+        </section>
+      </section>
+
+      <section class="guideline" id="onderscheidbaar">
+        <h3 id="x1-4-onderscheidbaar">
+          <span>Richtlijn </span><bdi class="secno">1.4 </bdi>Onderscheidbaar<a class="self-link" aria-label="§" href="#onderscheidbaar"></a>
+        </h3>
+        <p>
+          Maak het voor gebruikers gemakkelijker om content te horen en te zien,
+          waaronder scheiding van voorgrond en achtergrond.
+        </p>
+
+        <section class="sc" data-alt-id="use-of-color" id="gebruik-van-kleur">
+          <h4 id="x1-4-1-gebruik-van-kleur">
+            <span>Succescriterium </span><bdi class="secno">1.4.1 </bdi>Gebruik
+            van kleur<a class="self-link" aria-label="§" href="#gebruik-van-kleur"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html">Gebruik van kleur begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#use-of-color">Hoe te voldoen aan Gebruik van kleur</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Kleur wordt niet als het enige visuele middel gebruikt om informatie
+            over te brengen, een actie aan te geven, tot een reactie op te
+            roepen of een visueel element te onderscheiden.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-1">
+
+            <div role="heading" class="note-title marker" id="h-note-1" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Dit succescriterium richt zich specifiek op kleurperceptie. Andere
+              vormen van perceptie worden behandeld in
+              <a href="#aanpasbaar">Richtlijn 1.3</a> inclusief softwarematige
+              toegang tot kleur en andere codering van visuele presentatie.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="audio-control" id="geluidsbediening">
+          <h4 id="x1-4-2-geluidsbediening">
+            <span>Succescriterium </span><bdi class="secno">1.4.2 </bdi>Geluidsbediening<a class="self-link" aria-label="§" href="#geluidsbediening"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/audio-control.html">Geluidsbediening begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-control">Hoe te voldoen aan Geluidsbediening</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als een geluidsweergave op een webpagina automatisch meer dan 3
+            seconden speelt, is er of een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar om de geluidsweergave te pauzeren of te stoppen, of er
+            is een mechanisme beschikbaar om het geluidsvolume onafhankelijk van
+            het overall systeemvolume te regelen.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-2">
+
+            <div role="heading" class="note-title marker" id="h-note-2" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Omdat content die niet aan dit succescriterium voldoet het
+              vermogen van een gebruiker om de hele pagina te gebruiken kan
+              belemmeren, moet alle content op de webpagina (of die nu wel of
+              niet gebruikt wordt om aan andere succescriteria te voldoen) aan
+              dit succescriterium voldoen. Zie
+              <a href="#cc5"> Conformiteitseis 5: Niet-interferentie</a>.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="contrast-minimum" id="contrast-minimum">
+          <h4 id="x1-4-3-contrast-minimum">
+            <span>Succescriterium </span><bdi class="secno">1.4.3 </bdi>Contrast
+            (minimum)<a class="self-link" aria-label="§" href="#contrast-minimum"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html">Contrast (minimum) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum">Hoe te voldoen aan Contrast (minimum)</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            De visuele weergave van
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            en
+            <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">afbeeldingen van tekst</a>
+            heeft een
+            <a href="#dfn-contrastverhouding" class="internalDFN" data-link-type="dfn">contrastverhouding</a>
+            van ten minste 4,5:1, behalve in de volgende gevallen:
+          </p>
+
+          <dl>
+            <dt>Grote tekst</dt>
+
+            <dd>
+              <p>
+                <a href="#dfn-large-scale" class="internalDFN" data-link-type="dfn">Grote</a>
+                tekst en afbeeldingen van grote tekst hebben een
+                contrastverhouding van ten minste 3:1;
+              </p>
+            </dd>
+
+            <dt>Incidenteel</dt>
+
+            <dd>
+              <p>
+                Tekst of afbeeldingen van tekst die deel zijn van een inactieve
+                <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">component van de gebruikersinterface</a>, die
+                <a href="#dfn-puur-decoratief" class="internalDFN" data-link-type="dfn">puur decoratief</a>
+                zijn, die voor niemand zichtbaar zijn, of die onderdeel zijn van
+                een afbeelding die significant andere visuele content bevat,
+                hebben geen contrasteis.
+              </p>
+            </dd>
+
+            <dt>Woordmerken</dt>
+
+            <dd>
+              <p>
+                Tekst die onderdeel is van een logo of merknaam heeft geen
+                contrasteis.
+              </p>
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc" data-alt-id="resize-text" id="herschalen-van-tekst">
+          <h4 id="x1-4-4-herschalen-van-tekst">
+            <span>Succescriterium </span><bdi class="secno">1.4.4 </bdi>Herschalen van tekst<a class="self-link" aria-label="§" href="#herschalen-van-tekst"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html">Herschalen van tekst begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#resize-text">Hoe te voldoen aan Herschalen van tekst</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Behalve voor
+            <a href="#dfn-ondertitels" class="internalDFN" data-link-type="dfn">ondertitels</a>
+            voor doven en slechthorenden en
+            <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">afbeeldingen van tekst</a>, kan tekst zonder
+            <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologie</a>
+            tot 200% geschaald worden zonder verlies van content of
+            functionaliteit.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="images-of-text" id="afbeeldingen-van-tekst">
+          <h4 id="x1-4-5-afbeeldingen-van-tekst">
+            <span>Succescriterium </span><bdi class="secno">1.4.5 </bdi>Afbeeldingen van tekst<a class="self-link" aria-label="§" href="#afbeeldingen-van-tekst"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html">Afbeeldingen van tekst begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#images-of-text">Hoe te voldoen aan Afbeeldingen van tekst</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Als de gebruikte technologieën de visuele weergave tot stand kunnen
+            brengen, wordt
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            gebruikt in plaats van
+            <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">afbeeldingen van tekst</a>
+            om informatie over te brengen, behalve in de volgende gevallen:
+          </p>
+
+          <dl>
+            <dt>Aanpasbaar</dt>
+
+            <dd>
+              <p>
+                De afbeelding van tekst kan
+                <a href="#dfn-visueel-aangepast" class="internalDFN" data-link-type="dfn">visueel aangepast</a>
+                worden aan de eisen van de gebruiker;
+              </p>
+            </dd>
+
+            <dt>Essentieel</dt>
+
+            <dd>
+              <p>
+                Een specifieke weergave van tekst is
+                <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+                voor de informatie die wordt overgebracht.
+              </p>
+            </dd>
+          </dl>
+
+          <div class="note" role="note" id="issue-container-generatedID-3">
+
+            <div role="heading" class="note-title marker" id="h-note-3" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Woordmerken (tekst die onderdeel is van een logo of merknaam)
+              worden als essentieel beschouwd.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="contrast-enhanced" id="contrast-versterkt">
+          <h4 id="x1-4-6-contrast-versterkt">
+            <span>Succescriterium </span><bdi class="secno">1.4.6 </bdi>Contrast
+            (versterkt)<a class="self-link" aria-label="§" href="#contrast-versterkt"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html">Contrast (versterkt) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#contrast-enhanced">Hoe te voldoen aan Contrast (versterkt)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            De visuele weergave van
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            en
+            <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">afbeeldingen van tekst</a>
+            heeft een
+            <a href="#dfn-contrastverhouding" class="internalDFN" data-link-type="dfn">contrastverhouding</a>
+            van ten minste 7:1, behalve in de volgende gevallen:
+          </p>
+
+          <dl>
+            <dt>Grote tekst</dt>
+
+            <dd>
+              <p>
+                <a href="#dfn-large-scale" class="internalDFN" data-link-type="dfn">Grote</a>
+                tekst en afbeeldingen van grote tekst hebben een
+                contrastverhouding van ten minste 4,5:1;
+              </p>
+            </dd>
+
+            <dt>Incidenteel</dt>
+
+            <dd>
+              <p>
+                Tekst of afbeeldingen van tekst die onderdeel zijn van een
+                inactieve
+                <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>, die
+                <a href="#dfn-puur-decoratief" class="internalDFN" data-link-type="dfn">puur decoratief</a>
+                zijn, die voor niemand zichtbaar zijn, of die onderdeel zijn van
+                een afbeelding die significant andere visuele content bevat,
+                hebben geen contrasteis.
+              </p>
+            </dd>
+
+            <dt>Woordmerken</dt>
+
+            <dd>
+              <p>
+                Tekst die onderdeel is van een logo of merknaam heeft geen
+                contrasteis.
+              </p>
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc" data-alt-id="low-or-no-background-audio" id="weinig-of-geen-achtergrondgeluid">
+          <h4 id="x1-4-7-weinig-of-geen-achtergrondgeluid">
+            <span>Succescriterium </span><bdi class="secno">1.4.7 </bdi>Weinig
+            of geen achtergrondgeluid<a class="self-link" aria-label="§" href="#weinig-of-geen-achtergrondgeluid"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio.html">Weinig of geen achtergrondgeluid begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#low-or-no-background-audio">Hoe te voldoen aan Weinig of geen achtergrondgeluid</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Voor
+            <a href="#dfn-vooraf-opgenomen" class="internalDFN" data-link-type="dfn">vooraf opgenomen</a>
+            <a href="#dfn-louter-geluid" class="internalDFN" data-link-type="dfn">louter-geluid</a>content die (1) voornamelijk spraak op de voorgrond bevat, (2) geen
+            geluids-<a href="#dfn-captcha" class="internalDFN" data-link-type="dfn">CAPTCHA</a>
+            of audiologo is, en (3) geen vocalisatie is die primair bedoeld is
+            als muzikale expressie zoals zingen of rappen, is ten minste één van
+            de volgende zaken waar:
+          </p>
+
+          <dl>
+            <dt>Geen achtergrond:</dt>
+
+            <dd>
+              <p>De geluidsopname bevat geen achtergrondgeluiden.</p>
+            </dd>
+
+            <dt>Uitzetten</dt>
+
+            <dd>
+              <p>De achtergrondgeluiden kunnen uitgezet worden.</p>
+            </dd>
+
+            <dt>20 dB</dt>
+
+            <dd>
+              <p>
+                De achtergrondgeluiden zijn ten minste 20 decibel lager dan
+                spraak content die op de voorgrond klinkt, met uitzondering van
+                incidentele geluiden die slechts één of twee seconden duren.
+              </p>
+
+              <div class="note" role="note" id="issue-container-generatedID-4">
+
+                <div role="heading" class="note-title marker" id="h-note-4" aria-level="5">
+                  <span>Noot</span>
+                </div>
+                <p class="">
+                  Uit de definitie van "decibel" volgt dat achtergrondgeluid dat
+                  aan deze eis voldoet ongeveer vier keer zachter klinkt dan de
+                  spraak content op de voorgrond.
+                </p>
+              </div>
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc" data-alt-id="visual-presentation" id="visuele-weergave">
+          <h4 id="x1-4-8-visuele-weergave">
+            <span>Succescriterium </span><bdi class="secno">1.4.8 </bdi>Visuele
+            weergave<a class="self-link" aria-label="§" href="#visuele-weergave"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html">Visuele weergave begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#visual-presentation">Hoe te voldoen aan Visuele weergave</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Voor de visuele weergave van
+            <a href="#dfn-tekstblokken" class="internalDFN" data-link-type="dfn">tekstblokken</a>
+            is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar om het volgende te realiseren:
+          </p>
+
+          <ul>
+            <li>
+              Voor- en achtergrondkleuren kunnen door de gebruiker worden
+              gekozen.
+            </li>
+            <li>
+              De breedte is niet meer dan 80 karakters of tekens (40 in het
+              geval van CJK).
+            </li>
+            <li>
+              Tekst is niet uitgevuld (uitgelijnd naar linker- en
+              rechterkantlijnen).
+            </li>
+            <li>
+              Regelafstand is ten minste 1,5 spatie binnen alinea's en
+              alinea-afstand is ten minste 1,5 keer zo groot als de
+              regelafstand.
+            </li>
+            <li>
+              Tekst kan zonder hulptechnologie herschaald worden tot 200% op een
+              zodanige manier dat de gebruiker niet horizontaal hoeft te
+              scrollen om een regel tekst te lezen
+              <a href="#dfn-op-een-venster-even-groot-als-het-volle-beeld" class="internalDFN" data-link-type="dfn">op een venster even groot als het volle beeld</a>.
+            </li>
+          </ul>
+          <div class="note" role="note" id="issue-container-generatedID-5">
+            <div role="heading" class="note-title marker" id="h-note-5" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Content hoeft niet aan deze waarden te voldoen. De vereiste is 
+                dat er een mechanisme beschikbaar is voor gebruikers om deze weergaveaspecten 
+                te wijzigen. Het mechanisme kan worden geleverd door de browser of een andere 
+                user agent. Het is niet verplicht om in de content het mechanisme aan te bieden.
+            </p>
+          </div>
+          <div class="note" role="note" id="issue-container-generatedID-5">
+            <div role="heading" class="note-title marker" id="h-note-5" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Sommige talen gebruiken, als het om schriftsystemen gaat, verschillende weergaveaspecten
+                om leesbaarheid en duidelijkheid te verbeteren. Als een weergaveaspect in dit 
+                succescriterium niet wordt gebruikt in een schriftsysteem, dan hoeft de content 
+                die weergave-instelling niet te gebruiken om te voldoen. Auteurs worden aangemoedigd 
+                om handreikingen te volgen voor het verbeteren van de leesbaarheid en duidelijkheid 
+                van tekst in hun schriftsysteem. 
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="images-of-text-no-exception" id="afbeeldingen-van-tekst-geen-uitzondering">
+          <h4 id="x1-4-9-afbeeldingen-van-tekst-geen-uitzondering">
+            <span>Succescriterium </span><bdi class="secno">1.4.9 </bdi>Afbeeldingen van tekst (geen
+            uitzondering)<a class="self-link" aria-label="§" href="#afbeeldingen-van-tekst-geen-uitzondering"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text-no-exception.html">Afbeeldingen van tekst (geen uitzondering) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#images-of-text-no-exception">Hoe te voldoen aan Afbeeldingen van tekst (geen uitzondering)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">Afbeeldingen van tekst</a>
+            worden alleen
+            <a href="#dfn-puur-decoratief" class="internalDFN" data-link-type="dfn">puur decoratief</a>
+            gebruikt, of daar waar een specifieke weergave van
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+            is voor de informatie die wordt overgebracht.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-5">
+
+            <div role="heading" class="note-title marker" id="h-note-5" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Opmerking: woordmerken (tekst die onderdeel is van een logo of
+              merknaam) worden als essentieel beschouwd.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="reflow" id="reflow">
+          <h4 id="x1-4-10-reflow">
+            <span>Succescriterium </span><bdi class="secno">1.4.10 </bdi>Reflow<a class="self-link" aria-label="§" href="#reflow"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html">Reflow begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#reflow">Hoe te voldoen aan Reflow</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Content kan zonder verlies van informatie of functionaliteit en
+            zonder te moeten scrollen in twee dimensies, worden weergegeven
+            voor:
+          </p>
+
+          <ul>
+            <li>
+              Verticaal scrollbare content met een breedte gelijkwaardig aan 320
+              <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn">CSS-pixels</a>;
+            </li>
+            <li>
+              Horizontaal scrollbare content met een hoogte gelijkwaardig aan
+              256
+              <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn">CSS-pixels</a>;
+            </li>
+          </ul>
+
+          <p>
+            Met uitzondering van delen van de content die voor het gebruik of de
+            betekenis een tweedimensionale lay-out vereisen.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-6">
+
+            <div role="heading" class="note-title marker" id="h-note-6" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class=>
+              320 CSS-pixels zijn gelijk aan de beginbreedte van een
+              weergavekader van 1280 CSS-pixels bij 400% zoom. Voor webcontent
+              die ontworpen is om horizontaal te scrollen (bijv. bij verticale
+              tekst), zijn de 256 CSS-pixels gelijk aan de beginbreedte van een
+              weergavekader van 1024 CSS-pixels bij 400% zoom.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-7">
+
+            <div role="heading" class="note-title marker" id="h-note-7" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Voorbeelden van content die een tweedimensionale lay-out vereisen,
+              zijn afbeeldingen, kaarten, schema's, video's, games,
+              presentaties, gegevenstabellen en interfaces waarbij de werkbalken
+              zichtbaar moeten blijven tijdens het manipuleren van de content.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="non-text-contrast" id="contrast-van-niet-tekstuele-content">
+          <h4 id="x1-4-11-contrast-van-niet-tekstuele-content">
+            <span>Succescriterium </span><bdi class="secno">1.4.11 </bdi>Contrast van niet-tekstuele
+            content<a class="self-link" aria-label="§" href="#contrast-van-niet-tekstuele-content"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">Contrast van niet-tekstuele content begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast">Hoe te voldoen aan Contrast van niet-tekstuele content</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            De visuele weergave van het volgende heeft een
+            <a href="#dfn-contrastverhouding" class="internalDFN" data-link-type="dfn">contrastverhouding</a>
+            van ten minste 3:1 ten opzichte van aangrenzende kleuren:
+          </p>
+
+          <dl>
+            <dt>Componenten van de gebruikersinterface</dt>
+            <dd>
+              Visuele informatie die vereist is om
+              <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>
+              en
+              <a href="#dfn-statussen" class="internalDFN" data-link-type="dfn">statussen</a>
+              te identificeren, met uitzondering van inactieve componenten of
+              componenten waarvan de weergave van de component wordt bepaald
+              door de user agent en niet wordt aangepast door de auteur;
+            </dd>
+
+            <dt>Grafische objecten</dt>
+            <dd>
+              Delen van afbeeldingen die vereist zijn om de content te
+              begrijpen, behalve wanneer een specifieke weergave van
+              afbeeldingen
+              <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+              is voor de informatie die wordt overgebracht.
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc new" data-alt-id="text-spacing" id="tekstafstand">
+          <h4 id="x1-4-12-tekstafstand">
+            <span>Succescriterium </span><bdi class="secno">1.4.12 </bdi>Tekstafstand<a class="self-link" aria-label="§" href="#tekstafstand"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html">Tekstafstand begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#text-spacing">Hoe te voldoen aan Tekstafstand</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Bij content die wordt geïmplementeerd met opmaaktalen die de
+            volgende
+            <a href="#dfn-stijleigenschappen" class="internalDFN" data-link-type="dfn">stijleigenschappen</a>
+            voor
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            ondersteunen, is er geen sprake van verlies van content of
+            functionaliteit door het instellen van alle volgende, en door het
+            niet wijzigen van andere stijleigenschappen:
+          </p>
+
+          <ul>
+            <li>
+              Regelhoogte (regelafstand) naar ten minste 1,5 keer de
+              lettergrootte;
+            </li>
+            <li>
+              Afstand tussen alinea's naar ten minste 2 keer de lettergrootte;
+            </li>
+            <li>
+              Letterafstand (spatiëren van letters) naar ten minste 0,12 keer de
+              lettergrootte;
+            </li>
+            <li>
+              Spatiëren van woorden naar ten minste 0,16 keer de lettergrootte.
+            </li>
+          </ul>
+
+          <p>
+            Uitzondering: Menselijke talen en scripts die geen gebruik maken van
+            een of meer van deze eigenschappen voor tekststijl in schriftelijke
+            tekst, kunnen voldoen aan de eisen door alleen gebruik te maken van
+            de eigenschappen die bestaan voor de betreffende combinatie van taal
+            en script.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-0">
+
+            <div role="heading" class="note-title marker" id="h-note-0" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Het is niet verplicht om voor content deze waarden voor tekstafstand te gebruiken. 
+                De eis is om ervoor te zorgen dat als een gebruiker de ingestelde waarden vervangt, 
+                er dan geen content of functionaliteit verloren gaat.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-0">
+
+            <div role="heading" class="note-title marker" id="h-note-0" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Voor sommige talen gebruiken schriftsystemen verschillende instellingen voor tekstafstand, 
+                zoals inspringen aan het begin van een alinea. Auteurs worden aangemoedigd om lokaal beschikbare 
+                handreikingen te volgen voor het verbeteren van de leesbaarheid en duidelijkheid van tekst in hun 
+                schriftsystemen. 
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="content-on-hover-or-focus" id="content-bij-hover-of-focus">
+          <h4 id="x1-4-13-content-bij-hover-of-focus">
+            <span>Succescriterium </span><bdi class="secno">1.4.13 </bdi>Content
+            bij hover of focus<a class="self-link" aria-label="§" href="#content-bij-hover-of-focus"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html">Content bij hover of focus begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#content-on-hover-or-focus">Hoe te voldoen aan Content bij hover of focus</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Wanneer aanvullende content zichtbaar wordt en daarna weer
+            verborgen, door het gebruik van hover met de aanwijzer of focus met
+            het toetsenbord, gelden de volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Sluiten</dt>
+            <dd>
+              Er is een
+              <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+              beschikbaar waarmee de aanvullende content kan worden gesloten
+              zonder de aanwijzer hover of de toetsenbordfocus te verplaatsen,
+              tenzij de aanvullende content een
+              <a href="#dfn-invoerfout" class="internalDFN" data-link-type="dfn">invoerfout</a>
+              communiceert of andere content niet verbergt of vervangt;
+            </dd>
+
+            <dt>Aanwijsbaar</dt>
+            <dd>
+              Wanneer een aanwijzer hover aanvullende content kan activeren, dan
+              kan de aanwijzer over de aanvullende content worden bewogen zonder
+              dat deze verdwijnt;
+            </dd>
+
+            <dt>Aanhouden</dt>
+            <dd>
+              De aanvullende content blijft zichtbaar totdat de oorzaak voor de
+              hover of focus is verwijderd, de gebruiker de content sluit of de
+              informatie niet langer geldig is.
+            </dd>
+          </dl>
+
+          <p>
+            Uitzondering: De visuele weergave van de aanvullende content wordt
+            beheerd door de user agent en wordt niet aangepast door de auteur.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-0">
+
+            <div role="heading" class="note-title marker" id="h-note-0" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Voorbeelden van aanvullende content die door de user agent wordt bepaald, 
+                zijn de browser tooltips die worden gemaakt met behulp van het HTML title-attribuut. 
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-0">
+
+            <div role="heading" class="note-title marker" id="h-note-0" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Aangepaste tooltips, submenu's en andere niet-modale pop-ups die worden weergegeven 
+                bij hover en focus zijn voorbeelden van aanvullende content waarop dit criterium van 
+                toepassing is. 
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-0">
+
+            <div role="heading" class="note-title marker" id="h-note-0" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Dit criterium is van toepassing op content die aanvullend verschijnt met de activerende 
+                component zelf. Aangezien verborgen componenten die zichtbaar worden bij toetsenbordfocus 
+                (zoals links die worden gebruikt om naar een ander deel van een pagina te springen) 
+                geen aanvullende content presenteren, vallen ze niet onder dit criterium. 
+            </p>
+          </div>
+        </section>
+      </section>
+    </section>
+
+    <section class="principle" id="bedienbaar">
+      <h2 id="x2-bedienbaar">
+        <span>Principe </span><bdi class="secno">2. </bdi>Bedienbaar<a class="self-link" aria-label="§" href="#bedienbaar"></a>
+      </h2>
+      <p>
+        Componenten van de gebruikersinterface en navigatie moeten bedienbaar
+        zijn.
+      </p>
+
+      <section class="guideline" id="toetsenbordtoegankelijk">
+        <h3 id="x2-1-toetsenbordtoegankelijk">
+          <span>Richtlijn </span><bdi class="secno">2.1 </bdi>Toetsenbordtoegankelijk<a class="self-link" aria-label="§" href="#toetsenbordtoegankelijk"></a>
+        </h3>
+        <p>
+          Maak alle functionaliteit beschikbaar vanaf een toetsenbord.
+        </p>
+
+        <section class="sc" data-alt-id="keyboard" id="toetsenbord">
+          <h4 id="x2-1-1-toetsenbord">
+            <span>Succescriterium </span><bdi class="secno">2.1.1 </bdi>Toetsenbord<a class="self-link" aria-label="§" href="#toetsenbord"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html">Toetsenbord begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard">Hoe te voldoen aan Toetsenbord</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Alle
+            <a href="#dfn-functionaliteit" class="internalDFN" data-link-type="dfn">functionaliteit</a>
+            van de content is bedienbaar via een
+            <a href="#dfn-toetsenbordinterface" class="internalDFN" data-link-type="dfn">toetsenbordinterface</a>
+            zonder dat afzonderlijke toetsaanslagen aan tijd gebonden zijn,
+            behalve als de onderliggende functie een invoer vereist die afhangt
+            van het pad dat de gebruiker aflegt en niet alleen van de
+            eindpunten.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-10">
+
+            <div role="heading" class="note-title marker" id="h-note-10" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze uitzondering is gerelateerd aan de onderliggende functie,
+              niet aan de invoertechniek. Als we bijvoorbeeld met de hand
+              geschreven tekst invoeren, vereist de invoertechniek (met de hand
+              geschreven tekst) padafhankelijke invoer, maar de onderliggende
+              functie (tekstinvoer) vereist dat niet.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-11">
+
+            <div role="heading" class="note-title marker" id="h-note-11" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Dit succescriterium verbiedt geen muisinvoer of andere
+              invoermethoden naast de toetsenbordinvoer en wil dit ook niet
+              ontmoedigen.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="no-keyboard-trap" id="geen-toetsenbordval">
+          <h4 id="x2-1-2-geen-toetsenbordval">
+            <span>Succescriterium </span><bdi class="secno">2.1.2 </bdi>Geen
+            toetsenbordval<a class="self-link" aria-label="§" href="#geen-toetsenbordval"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html">Geen toetsenbordval begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#no-keyboard-trap">Hoe te voldoen aan Geen toetsenbordval</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als de toetsenbordfocus met de
+            <a href="#dfn-toetsenbordinterface" class="internalDFN" data-link-type="dfn">toetsenbordinterface</a>
+            verplaatst kan worden naar een component van de pagina, dan kan de
+            focus ook met alleen de toetsenbordinterface weer van dat component
+            weg worden bewogen. En, als er meer nodig is dan de standaard pijl-
+            of tabtoetsen of andere standaard methoden om de focus te
+            verplaatsen, dan wordt de gebruiker geïnformeerd over de manier
+            waarop de focus kan worden verplaatst.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-12">
+
+            <div role="heading" class="note-title marker" id="h-note-12" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Omdat content die niet aan dit succescriterium voldoet het
+              vermogen van een gebruiker om de hele pagina te gebruiken kan
+              belemmeren, moet alle content op de webpagina (ongeacht of deze
+              gebruikt wordt om aan andere succescriteria te voldoen of niet)
+              voldoen aan dit succescriterium. Zie
+              <a href="#cc5">Conformiteitseis 5: Niet-interferentie</a>.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="keyboard-no-exception" id="toetsenbord-geen-uitzondering">
+          <h4 id="x2-1-3-toetsenbord-geen-uitzondering">
+            <span>Succescriterium </span><bdi class="secno">2.1.3 </bdi>Toetsenbord (geen uitzondering)<a class="self-link" aria-label="§" href="#toetsenbord-geen-uitzondering"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard-no-exception.html">Toetsenbord (geen uitzondering) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard-no-exception">Hoe te voldoen aan Toetsenbord (geen uitzondering)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Alle
+            <a href="#dfn-functionaliteit" class="internalDFN" data-link-type="dfn">functionaliteit</a>
+            van de content is bedienbaar via een
+            <a href="#dfn-toetsenbordinterface" class="internalDFN" data-link-type="dfn">toetsenbordinterface</a>
+            zonder specifieke timing te vereisen voor de individuele
+            toetsaanslagen
+          </p>
+        </section>
+
+        <section class="sc new" data-alt-id="character-key-shortcuts" id="enkel-teken-sneltoetsen">
+          <h4 id="x2-1-4-enkel-teken-sneltoetsen">
+            <span>Succescriterium </span><bdi class="secno">2.1.4 </bdi>Enkel
+            teken sneltoetsen<a class="self-link" aria-label="§" href="#enkel-teken-sneltoetsen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html">Enkel teken sneltoetsen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#character-key-shortcuts">Hoe te voldoen aan Enkel teken sneltoetsen</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Wanneer een
+            <a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn">sneltoets</a>
+            in content wordt geïmplementeerd door alleen letters (inclusief
+            hoofdletters en kleine letters), leestekens, cijfers of symbolen te
+            gebruiken, geldt ten minste één van de volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Uitzetten</dt>
+            <dd>
+              Er is een
+              <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+              beschikbaar waarmee de sneltoets kan worden uitgezet;
+            </dd>
+
+            <dt>Opnieuw toewijzen</dt>
+            <dd>
+              Er is een mechanisme beschikbaar om de sneltoets opnieuw toe te
+              wijzen aan één of meerdere niet-afdrukbare tekens (bijv. Ctrl,
+              Alt, enz.);
+            </dd>
+
+            <dt>Alleen actief bij focus</dt>
+            <dd>
+              De sneltoets voor een
+              <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">component van de gebruikersinterface</a>
+              is alleen actief wanneer de betreffende component de focus heeft.
+            </dd>
+          </dl>
+        </section>
+      </section>
+
+      <section class="guideline" id="genoeg-tijd">
+        <h3 id="x2-2-genoeg-tijd">
+          <span>Richtlijn </span><bdi class="secno">2.2 </bdi>Genoeg tijd<a class="self-link" aria-label="§" href="#genoeg-tijd"></a>
+        </h3>
+        <p>
+          Geef gebruikers genoeg tijd om content te lezen en te gebruiken.
+        </p>
+
+        <section class="sc" data-alt-id="timing-adjustable" id="timing-aanpasbaar">
+          <h4 id="x2-2-1-timing-aanpasbaar">
+            <span>Succescriterium </span><bdi class="secno">2.2.1 </bdi>Timing
+            aanpasbaar<a class="self-link" aria-label="§" href="#timing-aanpasbaar"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html">Timing aanpasbaar begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#timing-adjustable">Hoe te voldoen aan Timing aanpasbaar</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Voor elke tijdslimiet die door de content wordt ingesteld, geldt ten
+            minste één van de volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Uitzetten</dt>
+            <dd>
+              <p>
+                De gebruiker kan de tijdslimiet uitzetten voordat die wordt
+                bereikt; of
+              </p>
+            </dd>
+
+            <dt>Aanpassen</dt>
+            <dd>
+              <p>
+                De gebruiker mag de tijdslimiet aanpassen voordat deze is
+                verstreken over een bereik van ten minste tien keer de
+                standaardinstelling; of
+              </p>
+            </dd>
+
+            <dt>Verlengen</dt>
+            <dd>
+              <p>
+                De gebruiker wordt gewaarschuwd voor de tijd afloopt en krijgt
+                ten minste 20 seconden om de tijdslimiet met een eenvoudige
+                handeling te verlengen (bijvoorbeeld, "druk op de spatiebalk"),
+                en de gebruiker mag de tijdslimiet ten minste tien keer
+                verlengen; of
+              </p>
+            </dd>
+
+            <dt>Real-time uitzondering:</dt>
+            <dd>
+              <p>
+                De tijdslimiet is onderdeel van een realtime gebeurtenis (een
+                veiling bijvoorbeeld) en er is geen alternatief voor de
+                tijdslimiet mogelijk; of
+              </p>
+            </dd>
+
+            <dt>Essentiële uitzondering:</dt>
+            <dd>
+              <p>
+                De tijdslimiet is
+                <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+                en verlenging zou de activiteit ongeldig maken; of
+              </p>
+            </dd>
+
+            <dt>20 uur uitzondering:</dt>
+            <dd>
+              <p>
+                De tijdslimiet is langer dan 20 uur.
+              </p>
+            </dd>
+          </dl>
+
+          <div class="note" role="note" id="issue-container-generatedID-13">
+
+            <div role="heading" class="note-title marker" id="h-note-13" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Dit succescriterium helpt om ervoor te zorgen dat gebruikers taken
+              kunnen voltooien zonder onverwachte veranderingen in content of
+              context die het resultaat zijn van een tijdslimiet. Dit
+              succescriterium moet in samenhang met
+              <a href="#bij-focus">Succescriterium 3.2.1</a> worden beschouwd,
+              dat limieten stelt aan veranderingen van content of context als
+              gevolg van een gebruikersactie.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="pause-stop-hide" id="pauzeren-stoppen-verbergen">
+          <h4 id="x2-2-2-pauzeren-stoppen-verbergen">
+            <span>Succescriterium </span><bdi class="secno">2.2.2 </bdi>Pauzeren, stoppen, verbergen<a class="self-link" aria-label="§" href="#pauzeren-stoppen-verbergen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html">Pauzeren, stoppen, verbergen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#pause-stop-hide">Hoe te voldoen aan Pauzeren, stoppen, verbergen</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Voor alle bewegende,
+            <a href="#dfn-knipperende" class="internalDFN" data-link-type="dfn">knipperende</a>, scrollende of automatisch actualiserende informatie gelden alle
+            volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Bewegen, knipperen, scrollen:</dt>
+            <dd>
+              <p>
+                Voor bewegende, knipperende of scrollende informatie die (1)
+                automatisch start, (2) langer dan vijf seconden duurt, en (3)
+                parallel met andere content wordt getoond, is er een mechanisme
+                voor de gebruiker om dit te
+                <a href="#dfn-pause" class="internalDFN" data-link-type="dfn">pauzeren</a>, te stoppen of te verbergen, tenzij de beweging, knippering of
+                scrolling, onderdeel is van een activiteit waar ze
+                <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+                is en
+              </p>
+            </dd>
+
+            <dt>Automatisch actualiserend:</dt>
+            <dd>
+              <p>
+                Voor elke soort automatisch actualiserende informatie die (1)
+                automatisch start en (2) parallel met andere content wordt
+                gepresenteerd, is er een mechanisme voor de gebruiker om dit te
+                pauzeren, te stoppen of te verbergen of de frequentie van de
+                actualisering in te stellen, tenzij de automatische
+                actualisering onderdeel is van een activiteit waar ze essentieel
+                is.
+              </p>
+            </dd>
+          </dl>
+
+          <div class="note" role="note" id="issue-container-generatedID-14">
+
+            <div role="heading" class="note-title marker" id="h-note-14" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Voor eisen gerelateerd aan knipperende of flitsende content zie
+              <a href="#toevallen-en-fysieke-reacties">Richtlijn 2.3</a>.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-15">
+
+            <div role="heading" class="note-title marker" id="h-note-15" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Omdat content die niet aan dit succescriterium voldoet het
+              vermogen van een gebruiker om de hele pagina te gebruiken kan
+              belemmeren, moet alle content op de webpagina (of ze gebruikt
+              wordt om aan andere succescriteria te voldoen of niet) voldoen aan
+              dit succescriterium. Zie
+              <a href="#cc5">conformiteitseis 5: Niet-interferentie</a>.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-16">
+
+            <div role="heading" class="note-title marker" id="h-note-16" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Van content die periodiek door software wordt geactualiseerd of
+              die naar de user agent wordt verzonden, wordt niet vereist dat ze
+              informatie behoudt of weergeeft die gegenereerd of ontvangen wordt
+              tussen het begin van de pauze en het moment van de hervatting van
+              de weergave, aangezien dit technisch wellicht niet mogelijk is en
+              het in veel situaties misleidend is om dit te doen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-17">
+
+            <div role="heading" class="note-title marker" id="h-note-17" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een animatie die speelt tijdens het laden of een gelijkwaardige
+              situatie, kan als essentieel worden beschouwd als niet
+              tegelijkertijd interactie kan plaatsvinden door alle gebruikers en
+              als het niet aangeven van de voortgang gebruikers zou kunnen
+              verwarren of laten denken dat de content vastgelopen of onvolledig
+              was.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="no-timing" id="geen-timing">
+          <h4 id="x2-2-3-geen-timing">
+            <span>Succescriterium </span><bdi class="secno">2.2.3 </bdi>Geen
+            timing<a class="self-link" aria-label="§" href="#geen-timing"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/no-timing.html">Geen timing begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#no-timing">Hoe te voldoen aan Geen timing</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Timing is geen
+            <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+            onderdeel van de gebeurtenis of activiteit die door de content wordt
+            weergegeven, behalve voor niet-interactieve
+            <a href="#dfn-gesynchroniseerde-media" class="internalDFN" data-link-type="dfn">gesynchroniseerde media</a>
+            en
+            <a href="#dfn-livegebeurtenis" class="internalDFN" data-link-type="dfn">real-time gebeurtenissen</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="interruptions" id="onderbrekingen">
+          <h4 id="x2-2-4-onderbrekingen">
+            <span>Succescriterium </span><bdi class="secno">2.2.4 </bdi>Onderbrekingen<a class="self-link" aria-label="§" href="#onderbrekingen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/interruptions.html">Onderbrekingen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#interruptions">Hoe te voldoen aan Onderbrekingen</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Onderbrekingen kunnen uitgesteld of uitgezet worden door de
+            gebruiker, behalve onderbrekingen die met een
+            <a href="#dfn-noodsituatie" class="internalDFN" data-link-type="dfn">noodsituatie</a>
+            samenhangen.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="re-authenticating" id="herauthentisering">
+          <h4 id="x2-2-5-herauthentisering">
+            <span>Succescriterium </span><bdi class="secno">2.2.5 </bdi>Herauthentisering<a class="self-link" aria-label="§" href="#herauthentisering"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/re-authenticating.html">Herauthentisering begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#re-authenticating">Hoe te voldoen aan Herauthentisering</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Als een geauthentiseerde sessie verloopt, kan de gebruiker na
+            herauthentisering de activiteit zonder gegevensverlies voortzetten.
+          </p>
+        </section>
+
+        <section class="sc new" data-alt-id="timeouts" id="time-outs">
+          <h4 id="x2-2-6-time-outs">
+            <span>Succescriterium </span><bdi class="secno">2.2.6 </bdi>Time-outs<a class="self-link" aria-label="§" href="#time-outs"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/timeouts.html">Time-outs begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#timeouts">Hoe te voldoen aan Time-outs</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Gebruikers worden gewaarschuwd voor een periode van
+            <a href="#dfn-gebruikersinactiviteit" class="internalDFN" data-link-type="dfn">gebruikersinactiviteit</a>
+            die kan leiden tot verlies van gegevens, tenzij de gegevens
+            gedurende meer dan 20 uur worden bewaard wanneer de gebruiker geen
+            actie onderneemt.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-18">
+
+            <div role="heading" class="note-title marker" id="h-note-18" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Privacyregelgeving vereist mogelijk dat de gebruiker uitdrukkelijk
+              toestemming moet geven alvorens de gebruikersidentificatie mag
+              worden geverifieerd en gebruikersgegevens mogen worden bewaard.
+              Wanneer de gebruiker minderjarig is, mag in de meeste
+              rechtsgebieden, landen of regio's mogelijk niet om uitdrukkelijke
+              toestemming worden gevraagd. Aanbevolen wordt om deskundigen op
+              het gebied van privacy te raadplegen en juridisch advies in te
+              winnen wanneer men het bewaren van gegevens als een mogelijkheid
+              beschouwd om aan dit succescriterium te voldoen.
+            </p>
+          </div>
+        </section>
+      </section>
+
+      <section class="guideline new" id="toevallen-en-fysieke-reacties">
+        <h3 id="x2-3-toevallen-en-fysieke-reacties">
+          <span>Richtlijn </span><bdi class="secno">2.3 </bdi>Toevallen en
+          fysieke reacties<a class="self-link" aria-label="§" href="#toevallen-en-fysieke-reacties"></a>
+        </h3>
+        <p>
+          Ontwerp content niet op een manier waarvan bekend is dat die toevallen
+          of fysieke reacties veroorzaakt.
+        </p>
+
+        <section class="sc" data-alt-id="three-flashes-or-below-threshold" id="drie-flitsen-of-beneden-drempelwaarde">
+          <h4 id="x2-3-1-drie-flitsen-of-beneden-drempelwaarde">
+            <span>Succescriterium </span><bdi class="secno">2.3.1 </bdi>Drie
+            flitsen of beneden drempelwaarde<a class="self-link" aria-label="§" href="#drie-flitsen-of-beneden-drempelwaarde"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html">Drie flitsen of beneden drempelwaarde begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#three-flashes-or-below-threshold">Hoe te voldoen aan Drie flitsen of beneden drempelwaarde</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">Webpagina's</a>
+            bevatten niets wat meer dan drie keer flitst in enige periode van
+            één seconde of de
+            <a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">flits</a>
+            is beneden de
+            <a href="#dfn-algemene-flits-en-rodeflitsdrempelwaarden" class="internalDFN" data-link-type="dfn">algemene flits- en rodeflitsdrempelwaarden</a>.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-19">
+
+            <div role="heading" class="note-title marker" id="h-note-19" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Omdat content die niet aan dit succescriterium voldoet het
+              vermogen van een gebruiker om de hele pagina te gebruiken kan
+              belemmeren, moet alle content op de webpagina (ongeacht of deze
+              gebruikt wordt om aan andere succescriteria te voldoen of niet)
+              voldoen aan dit succescriterium. Zie
+              <a href="#cc5">Conformiteitseis 5: Niet-interferentie</a>.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc" data-alt-id="three-flashes" id="drie-flitsen">
+          <h4 id="x2-3-2-drie-flitsen">
+            <span>Succescriterium </span><bdi class="secno">2.3.2 </bdi>Drie
+            flitsen<a class="self-link" aria-label="§" href="#drie-flitsen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/three-flashes.html">Drie flitsen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#three-flashes">Hoe te voldoen aan Drie flitsen</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">Webpagina's</a>
+            bevatten niets wat meer dan drie keer
+            <a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">flits</a>t in enige periode van één seconde.
+          </p>
+        </section>
+
+        <section class="sc new" data-alt-id="animation-from-interactions" id="animatie-uit-interacties">
+          <h4 id="x2-3-3-animatie-uit-interacties">
+            <span>Succescriterium </span><bdi class="secno">2.3.3 </bdi>Animatie
+            uit interacties<a class="self-link" aria-label="§" href="#animatie-uit-interacties"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html">Animatie uit interacties begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#animation-from-interactions">Hoe te voldoen aan Animatie uit interacties</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            <a href="#dfn-bewegingsanimatie" class="internalDFN" data-link-type="dfn">Bewegingsanimatie</a>
+            die door interactie wordt geactiveerd, kan worden uitgeschakeld,
+            behalve als de animatie
+            <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+            is voor de functionaliteit of voor de informatie die wordt
+            overgebracht.
+          </p>
+        </section>
+      </section>
+
+      <section class="guideline" id="navigeerbaar">
+        <h3 id="x2-4-navigeerbaar">
+          <span>Richtlijn </span><bdi class="secno">2.4 </bdi>Navigeerbaar<a class="self-link" aria-label="§" href="#navigeerbaar"></a>
+        </h3>
+        <p>
+          Lever manieren om gebruikers te helpen navigeren, content te vinden en
+          te bepalen waar ze zijn.
+        </p>
+
+        <section class="sc" data-alt-id="bypass-blocks" id="blokken-omzeilen">
+          <h4 id="x2-4-1-blokken-omzeilen">
+            <span>Succescriterium </span><bdi class="secno">2.4.1 </bdi>Blokken
+            omzeilen<a class="self-link" aria-label="§" href="#blokken-omzeilen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html">Blokken omzeilen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#bypass-blocks">Hoe te voldoen aan Blokken omzeilen</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Er is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar om blokken content die op meerdere
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            worden herhaald te omzeilen.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="page-titled" id="paginatitel">
+          <h4 id="x2-4-2-paginatitel">
+            <span>Succescriterium </span><bdi class="secno">2.4.2 </bdi>Paginatitel<a class="self-link" aria-label="§" href="#paginatitel"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html">Paginatitel begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#page-titled">Hoe te voldoen aan Paginatitel</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">Webpagina's</a>
+            hebben titels die het onderwerp of doel beschrijven.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="focus-order" id="focus-volgorde">
+          <h4 id="x2-4-3-focus-volgorde">
+            <span>Succescriterium </span><bdi class="secno">2.4.3 </bdi>Focus
+            volgorde<a class="self-link" aria-label="§" href="#focus-volgorde"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html">Focus volgorde begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#focus-order">Hoe te voldoen aan Focus volgorde</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als in
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            <a href="#dfn-sequentieel-genavigeerd" class="internalDFN" data-link-type="dfn">sequentieel genavigeerd</a>
+            kan worden en de navigatiesequenties hebben invloed op de betekenis
+            of het gebruik, dan krijgen focusbare componenten de focus in de
+            juiste volgorde waardoor betekenis en bedienbaarheid behouden
+            blijft.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="link-purpose-in-context" id="linkdoel-in-context">
+          <h4 id="x2-4-4-linkdoel-in-context">
+            <span>Succescriterium </span><bdi class="secno">2.4.4 </bdi>Linkdoel
+            (in context)<a class="self-link" aria-label="§" href="#linkdoel-in-context"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html">Linkdoel (in context) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-in-context">Hoe te voldoen aan Linkdoel (in context)</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Het
+            <a href="#dfn-purpose-of-each-link" class="internalDFN" data-link-type="dfn">linkdoel</a>
+            kan bepaald worden uit enkel de linktekst of uit de linktekst samen
+            met zijn
+            <a href="#dfn-door-software-bepaalde-linkcontext" class="internalDFN" data-link-type="dfn">door software bepaalde linkcontext</a>, behalve daar waar het doel van de link een
+            <a href="#dfn-purpose-of-each-link" class="internalDFN" data-link-type="dfn">dubbelzinnige betekenis kan hebben voor gebruikers in het
+              algemeen</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="multiple-ways" id="meerdere-manieren">
+          <h4 id="x2-4-5-meerdere-manieren">
+            <span>Succescriterium </span><bdi class="secno">2.4.5 </bdi>Meerdere
+            manieren<a class="self-link" aria-label="§" href="#meerdere-manieren"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/multiple-ways.html">Meerdere manieren begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#multiple-ways">Hoe te voldoen aan Meerdere manieren</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Er is meer dan één manier beschikbaar om een
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina</a>
+            binnen een
+            <a href="#dfn-verzameling-webpagina-s" class="internalDFN" data-link-type="dfn">verzameling webpagina's</a>
+            te vinden, behalve wanneer de webpagina het resultaat is van, of een
+            stap in, een
+            <a href="#dfn-processen" class="internalDFN" data-link-type="dfn">proces</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="headings-and-labels" id="koppen-en-labels">
+          <h4 id="x2-4-6-koppen-en-labels">
+            <span>Succescriterium </span><bdi class="secno">2.4.6 </bdi>Koppen
+            en labels<a class="self-link" aria-label="§" href="#koppen-en-labels"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html">Koppen en labels begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#headings-and-labels">Hoe te voldoen aan Koppen en labels</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Koppen en
+            <a href="#dfn-labels" class="internalDFN" data-link-type="dfn">labels</a>
+            beschrijven het onderwerp of doel.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="focus-visible" id="focus-zichtbaar">
+          <h4 id="x2-4-7-focus-zichtbaar">
+            <span>Succescriterium </span><bdi class="secno">2.4.7 </bdi>Focus
+            zichtbaar<a class="self-link" aria-label="§" href="#focus-zichtbaar"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html">Focus zichtbaar begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#focus-visible">Hoe te voldoen aan Focus zichtbaar</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Elke gebruikersinterface die met een toetsenbord te bedienen is,
+            heeft een bedieningswijze waarbij de indicator van de
+            toetsenbordfocus zichtbaar is.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="location" id="locatie">
+          <h4 id="x2-4-8-locatie">
+            <span>Succescriterium </span><bdi class="secno">2.4.8 </bdi>Locatie<a class="self-link" aria-label="§" href="#locatie"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/location.html">Locatie begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#location">Hoe te voldoen aan Locatie</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Informatie over de locatie van de gebruiker binnen een
+            <a href="#dfn-verzameling-webpagina-s" class="internalDFN" data-link-type="dfn">verzameling webpagina's</a>
+            is beschikbaar.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="link-purpose-link-only" id="linkdoel-alleen-link">
+          <h4 id="x2-4-9-linkdoel-alleen-link">
+            <span>Succescriterium </span><bdi class="secno">2.4.9 </bdi>Linkdoel
+            (alleen link)<a class="self-link" aria-label="§" href="#linkdoel-alleen-link"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html">Linkdoel (alleen link) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-link-only">Hoe te voldoen aan Linkdoel (alleen link)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar waarmee het doel van elke link bepaald kan worden op
+            basis van alleen de linktekst, behalve waar het doel van de link
+            <a href="#dfn-dubbelzinnig-voor-gebruikers-in-het-algemeen" class="internalDFN" data-link-type="dfn">dubbelzinnig voor gebruikers in het algemeen</a>
+            zou zijn.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="section-headings" id="paragraafkoppen">
+          <h4 id="x2-4-10-paragraafkoppen">
+            <span>Succescriterium </span><bdi class="secno">2.4.10 </bdi>Paragraafkoppen<a class="self-link" aria-label="§" href="#paragraafkoppen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/section-headings.html">Paragraafkoppen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#section-headings">Hoe te voldoen aan Paragraafkoppen</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            <a href="#dfn-paragraaf" class="internalDFN" data-link-type="dfn">Paragraaf</a>
+            koppen worden gebruikt om de content te structureren.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-20">
+
+            <div role="heading" class="note-title marker" id="h-note-20" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              "Kop" wordt in algemene zin gebruikt met inbegrip van titels en
+              andere manieren om een kop aan verschillende soorten content te
+              geven.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-21">
+
+            <div role="heading" class="note-title marker" id="h-note-21" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Dit succescriterium betreft paragrafen binnen de tekst, niet
+              <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>. Componenten van de gebruikersinterface vallen onder
+              <a href="#naam-rol-waarde">Succescriterium 4.1.2</a>.
+            </p>
+          </div>
+        </section>
+
+        <section class="guideline" id="focus-not-obscured-minimum"><div class="header-wrapper">
+            <h4 id="x2-4-11-focus-not-obscured-minimum"><bdi class="secno">Succescriterium 2.4.11 </bdi>Focus niet bedekt (minimum)</h4>
+            <a class="self-link" href="#focus-not-obscured-minimum" aria-label="Permalink for Section 2.4.11"></a></div>
+   
+    
+    
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">Focus niet bedekt (minimum) begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-minimum">Hoe te voldoen aan Focus niet bedekt (Minimum)</a></div><p class="conformance-level">(Niveau AA)</p>
+            <p class="change">[Nieuw]</p>
+            
+            <p>Wanneer een <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-7" title="a part of the content that is perceived by users as a single control for a distinct function">component van de gebruikersinterface</a> de toetsenbordfocus krijgt, wordt die component niet volledig bedekt door de content die door de auteur is gecreëerd. </p>
+        
+            <div class="note" role="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>Note 1</span></div><p class="">Waar content in een configureerbare interface door de gebruiker kan worden verplaatst, worden alleen de oorspronkelijke posities van door de gebruiker verplaatsbare content beoordeeld bij testen en conformiteit met dit succescriterium. </p></div>
+        
+            <div class="note" role="note" id="issue-container-generatedID-28"><div role="heading" class="note-title marker" id="h-note-28" aria-level="5"><span>Note 2</span></div><p class="">Content die de <em>gebruiker</em> opent, kan de component die focus ontvangt bedekken. Als de gebruiker de gefocuste component zichtbaar kan maken zonder de toetsenbordfocus te verplaatsen, wordt de component met focus niet beschouwd als bedekt door de content die door de auteur is gecreëerd.</p></div>
+        
+         </section>
+
+         <section class="guideline" id="focus-not-obscured-enhanced"><div class="header-wrapper"><h4 id="x2-4-12-focus-not-obscured-enhanced"><bdi class="secno">Succescriterium 2.4.12 </bdi>Focus niet bedekt (uitgebreid)</h4><a class="self-link" href="#focus-not-obscured-enhanced" aria-label="Permalink for Section 2.4.12"></a></div>
+   
+    
+    
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced.html">Focus niet bedekt (uitgebreid) begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-enhanced">Hoe te voldoen aan Focus niet bedekt (uitgebreid)</a></div><p class="conformance-level">(Niveau AAA)</p>
+            <p class="change">[Nieuw]</p>
+            
+            <p>Wanneer een <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-8" title="a part of the content that is perceived by users as a single control for a distinct function">component van de gebruikersinterface</a> de toetsenbordfocus krijgt, wordt geen enkel deel van die component bedekt door de content die door de auteur is gecreëerd.</p>
+        
+         </section>
+
+         <section class="guideline" id="focus-appearance"><div class="header-wrapper"><h4 id="x2-4-13-focus-appearance"><bdi class="secno">Succescriterium 2.4.13 </bdi>Focusweergave</h4><a class="self-link" href="#focus-appearance" aria-label="Permalink for Section 2.4.13"></a></div>
+   
+    
+    
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html">Focusweergave begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-appearance">How to Meet Focus Appearance</a></div><p class="conformance-level">(Niveau AAA)</p>
+            <p class="change">[Nieuw]</p>
+            
+            <p>Wanneer de <a href="#dfn-focus-indicator" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-focus-indicator-1" title="[New]">toetsenbordfocusindicator </a> zichtbaar is, voldoet een gebied van de focusindicator aan alle volgende voorwaarden:</p>
+            <ul>
+                <li>Het is minstens zo groot als het gebied van een 2 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-3" title="visual angle of about 0.0213 degrees">CSS pixel</a> dikke <a href="#dfn-perimeter" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-perimeter-1" title="[New]">omtrek</a> van de  niet-gefocuste component of subcomponent, en                </li>
+                <li>Het heeft een contrastverhouding van ten minste 3:1 tussen dezelfde pixels in de gefocuste en niet-gefocuste toestand.</li>
+            </ul>
+        
+            <p>Uitzonderingen:</p>
+            <ul>
+              <li>De focusindicator wordt bepaald door de <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-1" title="any software that retrieves and presents Web content for users">user agent</a> en kan niet worden aangepast door de auteur, of</li>
+                <li>De focusindicator en de achtergrondkleur van de indicator worden niet aangepast door de auteur.</li>
+            </ul>
+            
+            <div class="note" role="note" id="issue-container-generatedID-29"><div role="heading" class="note-title marker" id="h-note-29" aria-level="5"><span>Note 1</span></div><p class="">Wat wordt waargenomen als component van de gebruikersinterface of subcomponent (om de begrenzing of grootte te bepalen) hangt af van de visuele <a href="#dfn-presentation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-presentation-3" title="rendering of the content in a form to be perceived by users">weergave</a>. 
+                De visuele weergave omvat de zichtbare <a href="#dfn-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-content-1" title="information and sensory experience to be communicated to the user by means of a user agent, including code or markup that defines the content's structure, presentation, and interactions">content</a>, rand en component-specifieke achtergrond van een component. Het omvat geen schaduw- en gloedeffecten die buiten de content, achtergrond of rand van een component vallen.</p></div>
+        
+            <div class="note" role="note" id="issue-container-generatedID-30"><div role="heading" class="note-title marker" id="h-note-30" aria-level="5"><span>Note 2</span></div><p class="">
+                Voorbeelden van subcomponenten die een focusindicator kunnen ontvangen, zijn menu-items in een geopend uitklapmenu, of focusbare cellen in een raster. </p></div>
+        
+            <div class="note" role="note" id="issue-container-generatedID-31"><div role="heading" class="note-title marker" id="h-note-31" aria-level="5"><span>Note 3</span></div><p class="">Contrastberekeningen kunnen worden gebaseerd op kleuren die binnen de <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-1" title="mechanism for encoding instructions to be rendered, played or executed by user agents">technologie</a> 
+                (zoals HTML, CSS en SVG). Pixels die zijn aangepast door resolutieverbeteringen en anti-aliasing van de user agent kunnen worden genegeerd.</p></div>
+        
+         </section>
+      </section>
+
+      <section class="guideline new" id="input-modaliteiten">
+        <h3 id="x2-5-input-modaliteiten">
+          <span>Richtlijn </span><bdi class="secno">2.5 </bdi>Input
+          Modaliteiten<a class="self-link" aria-label="§" href="#input-modaliteiten"></a>
+        </h3>
+
+        <p>
+          Maak het eenvoudiger voor gebruikers om de functionaliteit te bedienen
+          met andere vormen van invoer dan alleen het toetsenbord.
+        </p>
+
+        <section class="sc new" data-alt-id="pointer-gestures" id="aanwijzergebaren">
+          <h4 id="x2-5-1-aanwijzergebaren">
+            <span>Succescriterium </span><bdi class="secno">2.5.1 </bdi>Aanwijzergebaren<a class="self-link" aria-label="§" href="#aanwijzergebaren"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures.html">Aanwijzergebaren begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#pointer-gestures">Hoe te voldoen aan Aanwijzergebaren</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Alle
+            <a href="#dfn-functionaliteit" class="internalDFN" data-link-type="dfn">functionaliteit</a>
+            waarmee bij de bediening gebruik wordt gemaakt van meerpunts- of
+            padgebaseerde gebaren, kan worden bediend met een
+            <a href="#dfn-enkele-aanwijzer" class="internalDFN" data-link-type="dfn">enkele aanwijzer</a>
+            zonder een padgebaseerd gebaar, tenzij een meerpunts- of
+            padgebaseerd gebaar
+            <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+            is.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-22">
+
+            <div role="heading" class="note-title marker" id="h-note-22" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze eis is van toepassing op webcontent die acties met de
+              aanwijzer interpreteert (NB: dit geldt niet voor acties die
+              vereist zijn om de user agent of hulptechnologie te bedienen).
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="pointer-cancellation" id="aanwijzerannulering">
+          <h4 id="x2-5-2-aanwijzerannulering">
+            <span>Succescriterium </span><bdi class="secno">2.5.2 </bdi>Aanwijzerannulering<a class="self-link" aria-label="§" href="#aanwijzerannulering"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html">Aanwijzerannulering begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#pointer-cancellation">Hoe te voldoen aan Aanwijzerannulering</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Voor
+            <a href="#dfn-functionaliteit" class="internalDFN" data-link-type="dfn">functionaliteit</a>
+            die kan worden bediend met een
+            <a href="#dfn-enkele-aanwijzer" class="internalDFN" data-link-type="dfn">enkele aanwijzer</a>, geldt ten minste één van de volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Geen down-event</dt>
+            <dd>
+              Het
+              <a href="#dfn-down-event" class="internalDFN" data-link-type="dfn">down-event</a>
+              van de aanwijzer wordt niet gebruikt om enig onderdeel van de
+              functie uit te voeren;
+            </dd>
+
+            <dt>Afbreken of ongedaan maken</dt>
+            <dd>
+              De functie wordt voltooid door het
+              <a href="#dfn-up-event" class="internalDFN" data-link-type="dfn">up-event</a>
+              en er is een
+              <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+              beschikbaar om de functie af te breken voordat deze wordt voltooid
+              of om de functie ongedaan te maken als deze is voltooid;
+            </dd>
+
+            <dt>Up reversal</dt>
+            <dd>
+              Met het up-event wordt elk resultaat van het voorgaande down-event
+              ongedaan gemaakt;
+            </dd>
+
+            <dt>Essentieel</dt>
+            <dd>
+              Het voltooien van de functie met het down-event is
+              <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>.
+            </dd>
+          </dl>
+
+          <div class="note" role="note" id="issue-container-generatedID-23">
+
+            <div role="heading" class="note-title marker" id="h-note-23" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Functies die het indrukken van een toets op het toetsenbord of het
+              numeriek toetsenbord nabootsen, worden als essentieel beschouwd.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-24">
+
+            <div role="heading" class="note-title marker" id="h-note-24" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze eis is van toepassing op webcontent die acties met de
+              aanwijzer interpreteert (dus dit geldt niet voor acties die
+              vereist zijn om de user agent of hulptechnologie te bedienen).
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="label-in-name" id="label-in-naam">
+          <h4 id="x2-5-3-label-in-naam">
+            <span>Succescriterium </span><bdi class="secno">2.5.3 </bdi>Label in
+            naam<a class="self-link" aria-label="§" href="#label-in-naam"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">Label in naam begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#label-in-name">Hoe te voldoen aan Label in naam</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Bij
+            <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>
+            met
+            <a href="#dfn-labels" class="internalDFN" data-link-type="dfn">labels</a>
+            die
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            of
+            <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">afbeeldingen van tekst</a>
+            bevatten, bevat de
+            <a href="#dfn-naam" class="internalDFN" data-link-type="dfn">naam</a>
+            de tekst die visueel wordt weergegeven.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-25">
+
+            <div role="heading" class="note-title marker" id="h-note-25" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een best practice is om de naam te laten beginnen met de tekst van
+              het label.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="motion-actuation" id="bewegingsactivering">
+          <h4 id="x2-5-4-bewegingsactivering">
+            <span>Succescriterium </span><bdi class="secno">2.5.4 </bdi>Bewegingsactivering<a class="self-link" aria-label="§" href="#bewegingsactivering"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html">Bewegingsactivering begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#motion-actuation">Hoe te voldoen aan Bewegingsactivering</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            <a href="#dfn-functionaliteit" class="internalDFN" data-link-type="dfn">Functionaliteit</a>
+            die kan worden bediend door de beweging van een apparaat of beweging
+            van een gebruiker, kan ook worden bediend met
+            <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>. De reactie op de beweging kan worden uitgeschakeld om onbedoelde
+            activering te voorkomen, behalve wanneer:
+          </p>
+
+          <dl>
+            <dt>Ondersteunde interface</dt>
+            <dd>
+              De beweging wordt gebruikt om de functionaliteit te bedienen via
+              een
+              <a href="#dfn-toegankelijkheid-ondersteund" class="internalDFN" data-link-type="dfn">door toegankelijkheid ondersteunde</a>
+              interface;
+            </dd>
+
+            <dt>Essentieel</dt>
+            <dd>
+              De beweging is
+              <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+              voor de functie en wanneer de reactie op de beweging wordt
+              uitgeschakeld, wordt de activiteit ongeldig gemaakt.
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc new" data-alt-id="target-size" id="grootte-van-het-aanwijsgebied">
+          <h4 id="x2-5-5-grootte-van-het-aanwijsgebied">
+            <span>Succescriterium </span><bdi class="secno">2.5.5 </bdi>Grootte
+            van het aanwijsgebied<a class="self-link" aria-label="§" href="#grootte-van-het-aanwijsgebied"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/target-size.html">Grootte van het aanwijsgebied begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#target-size">Hoe te voldoen aan Grootte van het aanwijsgebied</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            De grootte van het
+            <a href="#dfn-doelgebied" class="internalDFN" data-link-type="dfn">doelgebied</a>
+            voor
+            <a href="#dfn-pointer-inputs" class="internalDFN" data-link-type="dfn">aanwijzerinvoer</a>
+            is ten minste 44 bij 44
+            <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn">CSS-pixels</a>, behalve in de volgende gevallen:
+          </p>
+
+          <dl>
+            <dt>Gelijkwaardig</dt>
+            <dd>
+              Het doel is beschikbaar via een gelijkwaardige link of een
+              bedieningselement van ten minste 44 bij 44 CSS-pixels op dezelfde
+              pagina;
+            </dd>
+
+            <dt>Inline</dt>
+            <dd>
+              Het doel bevindt zich in een regel of tekstblok;
+            </dd>
+
+            <dt>User agent control</dt>
+            <dd>
+              De doelgrootte wordt bepaald door de user agent en wordt niet
+              aangepast door de auteur.
+            </dd>
+
+            <dt>Essentieel</dt>
+            <dd>
+              Een specifieke weergave van het doel is
+              <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+              voor de informatie die wordt overgebracht.
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc new" data-alt-id="concurrent-input-mechanisms" id="input-gelijktijdige-invoermechanismen">
+          <h4 id="x2-5-6-input-gelijktijdige-invoermechanismen">
+            <span>Succescriterium </span><bdi class="secno">2.5.6 </bdi>Input
+            gelijktijdige invoermechanismen<a class="self-link" aria-label="§" href="#input-gelijktijdige-invoermechanismen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms.html">Input gelijktijdige invoermechanismen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#concurrent-input-mechanisms">Hoe te voldoen aan Input gelijktijdige invoermechanismen</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Webcontent beperkt niet het gebruik van de invoermanieren die op een
+            platform beschikbaar zijn, behalve wanneer de beperking
+            <a href="#dfn-essentieel" class="internalDFN" data-link-type="dfn">essentieel</a>
+            is, deze vereist is om de beveiliging van de content te garanderen
+            of deze vereist is om gebruikersinstellingen te beschermen.
+          </p>
+        </section>
+
+        <section class="guideline" id="dragging-movements"><div class="header-wrapper"><h4 id="x2-5-7-dragging-movements"><bdi class="secno">Succescriterium 2.5.7 </bdi>Sleepbewegingen</h4><a class="self-link" href="#dragging-movements" aria-label="Permalink for Section 2.5.7"></a></div>
+   
+    
+    
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html">Understanding Dragging Movements</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#dragging-movements">How to Meet Dragging Movements</a></div><p class="conformance-level">(Niveau AA)</p>
+            <p class="change">[Nieuw]</p>
+            
+          <p>Alle <a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-6" title="processes and outcomes achievable through user action">functionaliteit</a> die voor de bediening gebruik maakt van een <a href="#dfn-dragging-movements" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-dragging-movements-1" title="[New]">sleepbeweging</a> kan worden bereikt door een<a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-single-pointer-3" title="pointer input that operates with one point of contact with the screen, including single taps and clicks, double-taps and clicks, long presses, and path-based gestures">enkele aanwijzer</a> zonder slepen, tenzij slepen <a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-14" title="if removed, would fundamentally change the information or functionality of the content, and information and functionality cannot be achieved in another way that would conform">essentieel</a> is of de functionaliteit wordt bepaald door de <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-2" title="any software that retrieves and presents Web content for users">user agent</a> en niet wordt aangepast door de auteur.</p>
+            <div class="note" role="note" id="issue-container-generatedID-36"><div role="heading" class="note-title marker" id="h-note-36" aria-level="5"><span>Note</span></div><p class="">Deze eis is van toepassing op webcontent die acties met de aanwijzer interpreteert (Dwz: dit geldt niet voor acties die vereist zijn om de user agent of hulptechnologie te bedienen). </p></div>
+           
+         </section>
+
+         <section class="guideline" id="target-size-minimum"><div class="header-wrapper"><h4 id="x2-5-8-target-size-minimum"><bdi class="secno">Succescriterium 2.5.8 </bdi>Grootte van het aanwijsgebied (minimum)</h4><a class="self-link" href="#target-size-minimum" aria-label="Permalink for Section 2.5.8"></a></div>
+   
+    
+    
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">Grootte van het aanwijsgebied (minimum) begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#target-size-minimum">Hoe te voldoen aan Grootte van het aanwijsgebied (minimum)</a></div><p class="conformance-level">(Niveau AA)</p>
+            <p class="change">[Nieuw]</p>
+            
+            <p>De grootte van het <a href="#dfn-targets" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-targets-2" title="region of the display that will accept a pointer action, such as the interactive area of a user interface component">aanwijsgebied</a> voor <a href="#dfn-pointer-inputs" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pointer-inputs-2" title="input from a device that can target a specific coordinate (or set of coordinates) on a screen, such as a mouse, pen, or touch contact">aanwijzerinvoer</a> is ten minste 24 bij 24 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-5" title="visual angle of about 0.0213 degrees">CSS pixels</a>, behalve in de volgende gevallen:</p>
+            <ul>
+                <li><strong>Afstand:</strong> Te kleine aanwijsgebieden (minder dan 24 bij 24 CSS-pixels) zijn gepositioneerd zodat als een cirkel met een diameter van 24 CSS-pixels wordt gecentreerd op het <a href="#dfn-bounding-boxes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-bounding-boxes-1" title="[New]">begrenzingskader</a> van elk aanwijsgebied, de cirkels geen ander aanwijsgebied of de cirkel voor een ander te klein aanwijsgebied overlappen;</li>
+                <li><strong>Gelijkwaardig:</strong> De functie kan worden bereikt via een ander bedieningselement op dezelfde pagina dat aan dit criterium voldoet;</li>
+                <li><strong>Inline:</strong> Het aanwijsgebied bevindt zich in een zin of de grootte ervan wordt op een andere manier beperkt door de regelhoogte van tekst die geen deel uitmaakt van het aanwijsgebied;</li>
+                <li><strong>Bepaald door user agent:</strong> De grootte van het aanwijsgebied wordt bepaald door de <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-3" title="any software that retrieves and presents Web content for users">user agent</a> en is niet aangepast door de auteur;</li>
+                <li><strong>Essentieel:</strong> Een specifieke <a href="#dfn-presentation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-presentation-4" title="rendering of the content in a form to be perceived by users">weergave</a> van het aanwijsgebied is <a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-15" title="if removed, would fundamentally change the information or functionality of the content, and information and functionality cannot be achieved in another way that would conform">essentieel</a> of is wettelijk vereist voor de betreffende informatie.</li>
+            </ul>
+            <div class="note" role="note" id="issue-container-generatedID-37"><div role="heading" class="note-title marker" id="h-note-37" aria-level="5"><span>Note 1</span></div><p class="">Aanwijsgebieden waarmee waarden ruimtelijk kunnen worden geselecteerd op basis van de positie binnen het gebied, worden beschouwd als 1 aanwijsgebied voor het succescriterium. Voorbeelden zijn schuifregelaars, kleurenkiezers die een kleurverloop weergeven, of bewerkbare gebieden waar je de cursor in kunt positioneren. </p></div>
+            <div class="note" role="note" id="issue-container-generatedID-38"><div role="heading" class="note-title marker" id="h-note-38" aria-level="5"><span>Note 2</span></div><p class="">Voor inline aanwijsgebieden moet de regelhoogte worden geïnterpreteerd als zijnde loodrecht op de tekstrichting. Bijvoorbeeld, bij een taal die verticaal wordt weergegeven, zou de regelhoogte horizontaal zijn. </p></div>
+        
+        </section>
+      </section>
+    </section>
+
+    <section class="principle" id="begrijpelijk">
+      <h2 id="x3-begrijpelijk">
+        <span>Principe </span><bdi class="secno">3. </bdi>Begrijpelijk<a class="self-link" aria-label="§" href="#begrijpelijk"></a>
+      </h2>
+      <p>
+        Informatie en de bediening van de gebruikersinterface moeten
+        begrijpelijk zijn.
+      </p>
+
+      <section class="guideline" id="leesbaar">
+        <h3 id="x3-1-leesbaar">
+          <span>Richtlijn </span><bdi class="secno">3.1 </bdi>Leesbaar<a class="self-link" aria-label="§" href="#leesbaar"></a>
+        </h3>
+        <p>
+          Maak tekstcontent leesbaar en begrijpelijk.
+        </p>
+
+        <section class="sc" data-alt-id="language-of-page" id="taal-van-de-pagina">
+          <h4 id="x3-1-1-taal-van-de-pagina">
+            <span>Succescriterium </span><bdi class="secno">3.1.1 </bdi>Taal van
+            de pagina<a class="self-link" aria-label="§" href="#taal-van-de-pagina"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html">Taal van de pagina begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#language-of-page">Hoe te voldoen aan Taal van de pagina</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            De standaard
+            <a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">menselijke taal</a>
+            van diverse
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            kan
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="language-of-parts" id="taal-van-onderdelen">
+          <h4 id="x3-1-2-taal-van-onderdelen">
+            <span>Succescriterium </span><bdi class="secno">3.1.2 </bdi>Taal van
+            onderdelen<a class="self-link" aria-label="§" href="#taal-van-onderdelen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html">Taal van onderdelen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#language-of-parts">Hoe te voldoen aan Taal van onderdelen</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            De
+            <a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">menselijke taal</a>
+            van elke passage of zin in de content kan
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden, behalve waar het gaat om eigennamen, technische termen,
+            woorden uit een onbepaalde taal en woorden of zinsdelen die deel
+            zijn gaan uitmaken van het jargon van de onmiddellijk omringende
+            tekst.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="unusual-words" id="ongebruikelijke-woorden">
+          <h4 id="x3-1-3-ongebruikelijke-woorden">
+            <span>Succescriterium </span><bdi class="secno">3.1.3 </bdi>Ongebruikelijke woorden<a class="self-link" aria-label="§" href="#ongebruikelijke-woorden"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/unusual-words.html">Ongebruikelijke woorden begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#unusual-words">Hoe te voldoen aan Ongebruikelijke woorden</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar voor de identificatie van specifieke definities van
+            woorden of zinsdelen die
+            <a href="#dfn-op-een-ongebruikelijke-of-beperkte-manier-gebruikt" class="internalDFN" data-link-type="dfn">op een ongebruikelijke of beperkte manier gebruikt</a>
+            worden, inclusief
+            <a href="#dfn-idioms" class="internalDFN" data-link-type="dfn">idiomatische uitdrukkingen</a>
+            en
+            <a href="#dfn-jargon" class="internalDFN" data-link-type="dfn">jargon</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="abbreviations" id="afkortingen">
+          <h4 id="x3-1-4-afkortingen">
+            <span>Succescriterium </span><bdi class="secno">3.1.4 </bdi>Afkortingen<a class="self-link" aria-label="§" href="#afkortingen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/abbreviations.html">Afkortingen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#abbreviations">Hoe te voldoen aan Afkortingen</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar voor de identificatie van de voluit geschreven vorm of
+            betekenis van
+            <a href="#dfn-abbreviations" class="internalDFN" data-link-type="dfn">afkortingen</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="reading-level" id="leesniveau">
+          <h4 id="x3-1-5-leesniveau">
+            <span>Succescriterium </span><bdi class="secno">3.1.5 </bdi>Leesniveau<a class="self-link" aria-label="§" href="#leesniveau"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/reading-level.html">Leesniveau begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#reading-level">Hoe te voldoen aan Leesniveau</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Als tekst, nadat eigennamen en titels verwijderd zijn, een
+            leesvaardigheid vereist die hoger is dan het
+            <a href="#dfn-basisonderwijs" class="internalDFN" data-link-type="dfn">lager middelbaar onderwijsniveau</a>, dan is
+            <a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn">aanvullende content</a>
+            beschikbaar, of er is een versie beschikbaar die geen
+            leesvaardigheid vereist die hoger is dan het lager middelbaar
+            onderwijsniveau.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="pronunciation" id="uitspraak">
+          <h4 id="x3-1-6-uitspraak">
+            <span>Succescriterium </span><bdi class="secno">3.1.6 </bdi>Uitspraak<a class="self-link" aria-label="§" href="#uitspraak"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/pronunciation.html">Uitspraak begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#pronunciation">Hoe te voldoen aan Uitspraak</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Er is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar voor het vaststellen van de specifieke uitspraak van
+            woorden indien de betekenis van de woorden in de context
+            dubbelzinnig is zonder kennis van de uitspraak.
+          </p>
+        </section>
+      </section>
+
+      <section class="guideline" id="voorspelbaar">
+        <h3 id="x3-2-voorspelbaar">
+          <span>Richtlijn </span><bdi class="secno">3.2 </bdi>Voorspelbaar<a class="self-link" aria-label="§" href="#voorspelbaar"></a>
+        </h3>
+        <p>
+          Maak het uiterlijk en de bediening van webpagina's voorspelbaar.
+        </p>
+
+        <section class="sc" data-alt-id="on-focus" id="bij-focus">
+          <h4 id="x3-2-1-bij-focus">
+            <span>Succescriterium </span><bdi class="secno">3.2.1 </bdi>Bij
+            focus<a class="self-link" aria-label="§" href="#bij-focus"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html">Bij focus begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#on-focus">Hoe te voldoen aan Bij focus</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als een
+            <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">component van de gebruikersinterface</a>
+            de focus krijgt, dan veroorzaakt dat geen
+            <a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">contextwijziging</a>.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="on-input" id="bij-input">
+          <h4 id="x3-2-2-bij-input">
+            <span>Succescriterium </span><bdi class="secno">3.2.2 </bdi>Bij
+            input<a class="self-link" aria-label="§" href="#bij-input"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/on-input.html">Bij input begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#on-input">Hoe te voldoen aan Bij input</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Verandering van de instelling van een
+            <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">component van de gebruikersinterface</a>
+            veroorzaakt niet automatisch een
+            <a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">contextwijziging</a>, tenzij de gebruiker geïnformeerd is over het gedrag vóór het
+            gebruik van de component.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="consistent-navigation" id="consistente-navigatie">
+          <h4 id="x3-2-3-consistente-navigatie">
+            <span>Succescriterium </span><bdi class="secno">3.2.3 </bdi>Consistente navigatie<a class="self-link" aria-label="§" href="#consistente-navigatie"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html">Consistente navigatie begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#consistent-navigation">Hoe te voldoen aan Consistente navigatie</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Navigatiemechanismen, die op meerdere
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            binnen een
+            <a href="#dfn-verzameling-webpagina-s" class="internalDFN" data-link-type="dfn">verzameling webpagina's</a>
+            herhaald worden, komen elke keer dat ze worden herhaald in
+            <a href="#dfn-dezelfde-relatieve-volgorde" class="internalDFN" data-link-type="dfn">dezelfde relatieve volgorde</a>
+            voor, tenzij een verandering wordt geïnitieerd door de gebruiker.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="consistent-identification" id="consistente-identificatie">
+          <h4 id="x3-2-4-consistente-identificatie">
+            <span>Succescriterium </span><bdi class="secno">3.2.4 </bdi>Consistente identificatie<a class="self-link" aria-label="§" href="#consistente-identificatie"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html">Consistente identificatie begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#consistent-identification">Hoe te voldoen aan Consistente identificatie</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Componenten die
+            <a href="#dfn-dezelfde-functionaliteit" class="internalDFN" data-link-type="dfn">dezelfde functionaliteit</a>
+            hebben binnen een
+            <a href="#dfn-verzameling-webpagina-s" class="internalDFN" data-link-type="dfn">verzameling webpagina's</a>
+            worden consistent geïdentificeerd.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="change-on-request" id="verandering-op-verzoek">
+          <h4 id="x3-2-5-verandering-op-verzoek">
+            <span>Succescriterium </span><bdi class="secno">3.2.5 </bdi>Verandering op verzoek<a class="self-link" aria-label="§" href="#verandering-op-verzoek"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/change-on-request.html">Verandering op verzoek begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#change-on-request">Hoe te voldoen aan Verandering op verzoek</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            <a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">Contextwijzigingen</a>
+            worden alleen geïnitieerd op verzoek van de gebruiker of er is een
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            beschikbaar om zulke veranderingen uit te zetten.
+          </p>
+        </section>
+
+        <section class="guideline" id="consistent-help"><div class="header-wrapper"><h4 id="x3-2-6-consistent-help"><bdi class="secno">Succescriterium 3.2.6 </bdi>Consistente hulp</h4><a class="self-link" href="#consistent-help" aria-label="Permalink for Section 3.2.6"></a></div>
+   
+    
+    
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html">Consistente hulp begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#consistent-help">Hoe te voldoen aan Consistente hulp</a></div><p class="conformance-level">(Niveau A)</p>
+            <p class="change">[Nieuw]</p>
+            
+          <p>Als een <a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-9" title="a non-embedded resource obtained from a single URI using HTTP plus any other resources that are used in the rendering or intended to be rendered together with it by a user agent">webpagina</a> een van de volgende <a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-12" title="process or technique for achieving a result">hulpmechanismen</a> bevat, en die mechanismes op meerdere webpagina's binnen een <a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-5" title="collection of web pages that share a common purpose and that are created by the same author, group or organization">verzameling webpagina's </a>worden herhaald, dan komen ze in dezelfde relatieve volgorde voor ten opzichte van andere paginacontent, tenzij een wijziging wordt geïnitieerd door de gebruiker:
+        
+            <ul>
+                <li>Menselijke contactgegevens;</li>
+                <li>Menselijk contactmechanisme;</li>
+                <li>Zelfhulpoptie;</li>
+                <li>Een volledig geautomatiseerd contactmechanisme.</li>
+            </ul>
+        
+          <div class="note" role="note" id="issue-container-generatedID-39"><div role="heading" class="note-title marker" id="h-note-39" aria-level="5"><span>Note 1</span></div><p class="">Hulpmechanismen kunnen direct op de pagina worden aangeboden, of kunnen worden aangeboden via een directe link naar een andere pagina met die informatie. </p></div>
+          <div class="note" role="note" id="issue-container-generatedID-40"><div role="heading" class="note-title marker" id="h-note-40" aria-level="5"><span>Note 2</span></div><p class="">Voor dit succescriterium kan ‘dezelfde relatieve volgorde ten opzichte van andere paginacontent’ worden gezien als hoe de content is geordend wanneer de pagina onderdeel is van een serie pagina’s. De visuele positie van een hulpmechanisme is doorgaans consistent bij pagina’s met dezelfde paginavariant (bijv. CSS-break-point). De gebruiker kan een wijziging initiëren, zoals het wijzigen van de zoom of de oriëntatie van de pagina. Dat kan een andere paginavariant veroorzaken. Dit criterium heeft betrekking op de relatieve volgorde binnen pagina's die worden weergegeven in dezelfde paginavariant (bijv. hetzelfde zoomniveau en oriëntatie). </p></div>
+        
+         </section>
+      </section>
+
+      <section class="guideline" id="assistentie-bij-invoer">
+        <h3 id="x3-3-assistentie-bij-invoer">
+          <span>Richtlijn </span><bdi class="secno">3.3 </bdi>Assistentie bij
+          invoer<a class="self-link" aria-label="§" href="#assistentie-bij-invoer"></a>
+        </h3>
+        <p>
+          Help gebruikers om fouten te vermijden en ze te verbeteren.
+        </p>
+
+        <section class="sc" data-alt-id="error-identification" id="foutidentificatie">
+          <h4 id="x3-3-1-foutidentificatie">
+            <span>Succescriterium </span><bdi class="secno">3.3.1 </bdi>Foutidentificatie<a class="self-link" aria-label="§" href="#foutidentificatie"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html">Foutidentificatie begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-identification">Hoe te voldoen aan Foutidentificatie</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als een
+            <a href="#dfn-invoerfout" class="internalDFN" data-link-type="dfn">invoerfout</a>
+            automatisch ontdekt wordt, dan wordt het onderdeel waar de fout zit
+            geïdentificeerd en wordt de fout tekstueel aan de gebruiker
+            meegedeeld.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="labels-or-instructions" id="labels-of-instructies">
+          <h4 id="x3-3-2-labels-of-instructies">
+            <span>Succescriterium </span><bdi class="secno">3.3.2 </bdi>Labels
+            of instructies<a class="self-link" aria-label="§" href="#labels-of-instructies"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html">Labels of instructies begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#labels-or-instructions">Hoe te voldoen aan Labels of instructies</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Als de content gebruikersinvoer vereist, dan worden
+            <a href="#dfn-labels" class="internalDFN" data-link-type="dfn">labels</a>
+            of instructies geleverd.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="error-suggestion" id="foutsuggestie">
+          <h4 id="x3-3-3-foutsuggestie">
+            <span>Succescriterium </span><bdi class="secno">3.3.3 </bdi>Foutsuggestie<a class="self-link" aria-label="§" href="#foutsuggestie"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html">Foutsuggestie begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-suggestion">Hoe te voldoen aan Foutsuggestie</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Als een
+            <a href="#dfn-invoerfout" class="internalDFN" data-link-type="dfn">invoerfout</a>
+            automatisch ontdekt wordt en suggesties voor verbetering bekend
+            zijn, dan worden de suggesties aan de gebruiker geleverd, tenzij dit
+            de beveiliging of het doel van de content in gevaar zou brengen.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="error-prevention-legal-financial-data" id="foutpreventie-wettelijk-financieel-gegevens">
+          <h4 id="x3-3-4-foutpreventie-wettelijk-financieel-gegevens">
+            <span>Succescriterium </span><bdi class="secno">3.3.4 </bdi>Foutpreventie (wettelijk,
+            financieel, gegevens)<a class="self-link" aria-label="§" href="#foutpreventie-wettelijk-financieel-gegevens"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html">Foutpreventie (wettelijk, financieel, gegevens) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-prevention-legal-financial-data">Hoe te voldoen aan Foutpreventie (wettelijk, financieel,
+              gegevens)</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            Voor
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            die
+            <a href="#dfn-wettelijke-verplichtingen" class="internalDFN" data-link-type="dfn">wettelijke verplichtingen</a>
+            of financiële transacties voor de gebruiker uitvoeren, die, door
+            <a href="#dfn-gebruikers-bedienbaar" class="internalDFN" data-link-type="dfn">gebruikers bedienbaar</a>
+            gegevens in gegevensopslagplaatsen verwijderen of wijzigen, of die
+            antwoorden van de gebruiker verzenden, geldt ten minste één van de
+            volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Omkeerbaar</dt>
+            <dd>
+              Verzendingen kunnen ongedaan gemaakt worden.
+            </dd>
+
+            <dt>Gecontroleerd</dt>
+            <dd>
+              Door de gebruiker ingevoerde gegevens worden gecontroleerd op
+              invoerfouten en de gebruiker wordt de mogelijkheid gegeven om ze
+              te verbeteren.
+            </dd>
+
+            <dt>Bevestigd</dt>
+            <dd>
+              Er is een mechanisme beschikbaar voor het beoordelen, bevestigen
+              en verbeteren van informatie voordat de verzending wordt voltooid.
+            </dd>
+          </dl>
+        </section>
+
+        <section class="sc" data-alt-id="help" id="hulp">
+          <h4 id="x3-3-5-hulp">
+            <span>Succescriterium </span><bdi class="secno">3.3.5 </bdi>Hulp<a class="self-link" aria-label="§" href="#hulp"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/help.html">Hulp begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#help">Hoe te voldoen aan Hulp</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            <a href="#dfn-contextgevoelige-hulp" class="internalDFN" data-link-type="dfn">Contextgevoelige hulp</a>
+            is beschikbaar.
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="error-prevention-all" id="foutpreventie-alle">
+          <h4 id="x3-3-6-foutpreventie-alle">
+            <span>Succescriterium </span><bdi class="secno">3.3.6 </bdi>Foutpreventie (alle)<a class="self-link" aria-label="§" href="#foutpreventie-alle"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-all.html">Foutpreventie (alle) begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-prevention-all">Hoe te voldoen aan Foutpreventie (alle)</a>
+          </div>
+          <p class="conformance-level">(Niveau AAA)</p>
+
+          <p>
+            Voor
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            die vereisen dat de gebruiker informatie invoert en verzendt, geldt
+            ten minste één van de volgende zaken:
+          </p>
+
+          <dl>
+            <dt>Omkeerbaar</dt>
+            <dd>
+              Verzendingen kunnen ongedaan gemaakt worden.
+            </dd>
+
+            <dt>Gecontroleerd</dt>
+            <dd>
+              Door de gebruiker ingevoerde gegevens worden gecontroleerd op
+              invoerfouten en de gebruiker wordt de mogelijkheid gegeven om ze
+              te verbeteren.
+            </dd>
+
+            <dt>Bevestigd</dt>
+            <dd>
+              Er is een mechanisme beschikbaar voor het beoordelen, bevestigen
+              en verbeteren van informatie voordat de verzending wordt voltooid.
+            </dd>
+          </dl>
+        </section>
+      </section>
+
+      <section class="guideline" id="redundant-entry"><div class="header-wrapper"><h4 id="x3-3-7-redundant-entry"><bdi class="secno">Succescriterium 3.3.7 </bdi>Overbodige invoer</h4><a class="self-link" href="#redundant-entry" aria-label="Permalink for Section 3.3.7"></a></div>
+   
+    
+    
+        <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">Overbodige invoer begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#redundant-entry">Hoe te voldoen aan Overbodige invoer</a></div><p class="conformance-level">(Niveau A)</p>
+        <p class="change">[Nieuw]</p>
+        
+        <p>Informatie die eerder is ingevoerd door of aangeboden aan de gebruiker en opnieuw moet worden ingevoerd tijdens hetzelfde <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-2" title="series of user actions where each action is required in order to complete an activity">proces</a> is:</p>
+    
+        <ul>
+            <li>automatisch ingevuld, of</li>
+            <li>beschikbaar voor de gebruiker om te selecteren.</li>
+        </ul>
+        <p>Behalve wanneer:</p> 
+        <ul>
+            <li>opnieuw invoeren van de informatie <a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-16" title="if removed, would fundamentally change the information or functionality of the content, and information and functionality cannot be achieved in another way that would conform">essentieel</a>is,</li>
+            <li>de informatie nodig is om de security van de content te waarborgen, of</li>
+            <li>eerder ingevoerde informatie niet langer geldig is.</li>
+        </ul>
+    
+     </section>
+
+     <section class="guideline" id="accessible-authentication-minimum"><div class="header-wrapper"><h4 id="x3-3-8-accessible-authentication-minimum"><bdi class="secno">Succescriterium 3.3.8 </bdi>Toegankelijke authenticatie (minimum)</h4><a class="self-link" href="#accessible-authentication-minimum" aria-label="Permalink for Section 3.3.8"></a></div>
+   
+    
+    
+        <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">Toegankelijke authenticatie (minimum) begrijpen </a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-minimum">Hoe te voldoen aan Toegankelijke authenticatie (minimum) </a></div><p class="conformance-level">(Niveau AA)</p>
+        <p class="change">[Nieuw]</p>
+        
+        <p>Een <a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="[New]">cognitieve functietest</a> (zoals het onthouden van een wachtwoord of het oplossen van een puzzel) is bij geen enkele stap van een authenticatie <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="series of user actions where each action is required in order to complete an activity">proces</a> verplicht, tenzij die stap ten minste een van de volgende opties biedt:</p> 
+        <dl>
+            <dt>Alternatief</dt>
+            <dd>Een andere authenticatiemethode die niet afhankelijk is van een cognitieve functietest. </dd>
+            <dt>Mechanisme</dt>
+          <dd>Er is een <a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-13" title="process or technique for achieving a result">mechanisme</a> beschikbaar om de gebruiker te helpen bij het voltooien van de cognitieve functietest.</dd>
+            <dt>Objectherkenning</dt>
+            <dd>De cognitieve functietest is gericht op het herkennen van objecten.</dd>
+            <dt>Persoonlijke content</dt>
+          <dd>De cognitieve functietest is gericht op het identificeren van <a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-non-text-content-2" title="any content that is not a sequence of characters that can be programmatically determined or where the sequence is not expressing something in human language">niet-tekstuele content</a> die de gebruiker aan de website heeft verstrekt.</dd>
+        </dl>
+    
+        <div class="note" role="note" id="issue-container-generatedID-41"><div role="heading" class="note-title marker" id="h-note-41" aria-level="5"><span>Note 1</span></div><p class="">‘Objectherkenning’ en ‘Persoonlijke content’ kunnen worden weergegeven door afbeeldingen, video of audio. </p></div>
+        <div class="note" role="note" id="issue-container-generatedID-42"><div role="heading" class="note-title marker" id="h-note-42" aria-level="5"><span>Note 2</span></div><div class="">Voorbeelden van mechanismen die aan dit criterium voldoen, omvatten:
+            <ol>
+                <li>ondersteuning van wachtwoordinvoer door wachtwoordmanagers om de geheugenbehoefte te verminderen, en</li>
+                <li>kopiëren en plakken om de cognitieve belasting van opnieuw intypen te verminderen.</li>
+            </ol>
+        </div></div>
+        
+     </section>
+
+     <section class="guideline" id="accessible-authentication-enhanced"><div class="header-wrapper"><h4 id="x3-3-9-accessible-authentication-enhanced"><bdi class="secno">Succescriterium 3.3.9 </bdi>Toegankelijke authenticatie (uitgebreid)</h4><a class="self-link" href="#accessible-authentication-enhanced" aria-label="Permalink for Section 3.3.9"></a></div>
+   
+    
+    
+        <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html">Toegankelijke authenticatie (uitgebreid) begrijpen</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-enhanced">Hoe te voldoen aan Toegankelijke authenticatie (uitgebreid)</a></div><p class="conformance-level">(Niveau AAA)</p>
+        <p class="change">[Nieuw]</p>
+        
+        <p>Een <a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-2" title="[New]">cognitieve functietest</a> (zoals het onthouden van een wachtwoord of het oplossen van een puzzel) is bij geen enkele stap van een <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-4" title="series of user actions where each action is required in order to complete an activity">authenticatieproces </a> verplicht, tenzij die stap ten minste een van de volgende opties biedt:
+        <dl>
+            <dt>Alternatief</dt>
+            <dd>Een andere authenticatiemethode die niet afhankelijk is van een cognitieve functietest.</dd>
+            <dt>Mechanisme</dt>
+            <dd>Er is een <a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-14" title="process or technique for achieving a result">mechanisme</a> beschikbaar om de gebruiker te helpen bij het voltooien van de cognitieve functietest.</dd>
+        </dl>
+        
+     </section>
+    </section>
+
+    <section class="principle" id="robuust">
+      <h2 id="x4-robuust">
+        <span>Principe </span><bdi class="secno">4. </bdi>Robuust<a class="self-link" aria-label="§" href="#robuust"></a>
+      </h2>
+      <p>
+        Content moet voldoende robuust zijn om betrouwbaar geïnterpreteerd te
+        kunnen worden door een breed scala van user agents, met inbegrip van
+        hulptechnologieën.
+      </p>
+
+      <section class="guideline" id="compatibel">
+        <h3 id="x4-1-compatibel">
+          <span>Richtlijn </span><bdi class="secno">4.1 </bdi>Compatibel<a class="self-link" aria-label="§" href="#compatibel"></a>
+        </h3>
+        <p>
+          Maximaliseer compatibiliteit met huidige en toekomstige user agents,
+          met inbegrip van hulptechnologieën.
+        </p>
+
+        <section class="sc" data-alt-id="parsing" id="parsen">
+          <h4 id="x4-1-1-parsen">
+            <span>Succescriterium </span><bdi class="secno">4.1.1 </bdi>Parsen (Verouderd en verwijderd)<a class="self-link" aria-label="§" href="#parsen"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html">Parsen begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#parsing">Hoe te voldoen aan Parsen</a>
+          </div>
+          <p class="conformance-level"></p>
+
+
+          <div class="note" role="note" id="issue-container-generatedID-26">
+
+            <div role="heading" class="note-title marker" id="h-note-26" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+                Dit criterium werd oorspronkelijk aangenomen om problemen aan te pakken die hulptechnologie had bij het direct parsen van HTML Hulptechnologie hoeft HTML niet meer rechtstreeks te parsen. Als gevolg hiervan bestaan deze problemen niet meer of worden ze opgevangen door andere criteria. Dit criterium heeft geen nut meer en is verwijderd. 
+            </p>
+          </div>
+
+          <p>
+            Dit criterium werd oorspronkelijk aangenomen om problemen die hulptechnologie had bij het direct parsen van HTML. 
+          </p>
+        </section>
+
+        <section class="sc" data-alt-id="name-role-value" id="naam-rol-waarde">
+          <h4 id="x4-1-2-naam-rol-waarde">
+            <span>Succescriterium </span><bdi class="secno">4.1.2 </bdi>Naam,
+            rol, waarde<a class="self-link" aria-label="§" href="#naam-rol-waarde"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html">Naam, rol, waarde begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#name-role-value">Hoe te voldoen aan Naam, rol, waarde</a>
+          </div>
+          <p class="conformance-level">(Niveau A)</p>
+
+          <p>
+            Voor alle
+            <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>
+            (inclusief, maar niet uitsluitend voor formulierelementen, links en
+            door scripts gegenereerde componenten), kunnen de
+            <a href="#dfn-naam" class="internalDFN" data-link-type="dfn">naam</a>
+            (name) en
+            <a href="#dfn-rol" class="internalDFN" data-link-type="dfn">rol</a>
+            (role)
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden; toestanden (states), eigenschappen (properties) en waarden
+            (values) die door de gebruiker ingesteld kunnen worden, kunnen door
+            software ingesteld worden; en kennisgeving van veranderingen in deze
+            items is beschikbaar voor
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agents</a>, met inbegrip van
+            <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologieën</a>.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-27">
+
+            <div role="heading" class="note-title marker" id="h-note-27" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Dit succescriterium is primair voor webauteurs die hun eigen
+              componenten van de gebruikersinterface ontwikkelen of scripten.
+              Standaard bedieningselementen in HTML bijvoorbeeld voldoen al aan
+              dit succescriterium als ze gebruikt worden volgens specificatie.
+            </p>
+          </div>
+        </section>
+
+        <section class="sc new" data-alt-id="status-messages" id="statusberichten">
+          <h4 id="x4-1-3-statusberichten">
+            <span>Succescriterium </span><bdi class="secno">4.1.3 </bdi>Statusberichten<a class="self-link" aria-label="§" href="#statusberichten"></a>
+          </h4>
+
+          <div class="doclinks">
+            <a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html">Statusberichten begrijpen</a>
+            <span class="screenreader">|</span> <br /><a href="https://www.w3.org/WAI/WCAG21/quickref/#status-messages">Hoe te voldoen aan Statusberichten</a>
+          </div>
+          <p class="conformance-level">(Niveau AA)</p>
+
+          <p>
+            In content die is geïmplementeerd met opmaaktalen kunnen
+            <a href="#dfn-statusberichten" class="internalDFN" data-link-type="dfn">statusberichten</a>
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            worden met behulp van
+            <a href="#dfn-rol" class="internalDFN" data-link-type="dfn">rol</a>
+            (role) of eigenschappen (properties), zodat
+            <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologieën</a>
+            de berichten aan de gebruiker kunnen presenteren zonder dat ze de
+            focus krijgen.
+          </p>
+        </section>
+      </section>
+    </section>
+
+    <section id="conformiteit">
+      <h2 id="x5-conformiteit">
+        <bdi class="secno">5. </bdi>Conformiteit<a class="self-link" aria-label="§" href="#conformiteit"></a>
+      </h2>
+      <p>
+        Dit hoofdstuk zet
+        <a href="#dfn-conformiteitseisen" class="internalDFN" data-link-type="dfn">conformiteitseisen</a>
+        voor WCAG 2.1 op een rij. Het geeft ook informatie over het maken van
+        conformiteitsclaims. Conformiteitsclaims zijn optioneel. Ten slotte
+        beschrijft dit hoofdstuk wat het betekent om door toegankelijkheid
+        ondersteund te zijn, aangezien alleen
+        <a href="#dfn-toegankelijkheid-ondersteund" class="internalDFN" data-link-type="dfn">door toegankelijkheid ondersteunde</a>
+        manieren om technologie te gebruiken
+        <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">gesteund worden</a>
+        voor conformiteit.
+        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance</a>
+        geeft verdere uitleg van het begrip door toegankelijkheid ondersteund.
+      </p>
+
+      <section id="normatieve-eisen-interpreteren">
+        <h3 id="x5-1-normatieve-eisen-interpreteren">
+          <bdi class="secno">5.1 </bdi>Normatieve eisen interpreteren<a class="self-link" aria-label="§" href="#normatieve-eisen-interpreteren"></a>
+        </h3>
+        <p>
+          De belangrijkste inhoud van WCAG 2.1 is
+          <a href="#dfn-normatief" class="internalDFN" data-link-type="dfn">normatief</a>
+          en definieert de eisen die invloed hebben op conformiteitsclaims.
+          Inleidend materiaal, bijlagen, paragrafen die zijn gemarkeerd als
+          "niet-normatief", schema's, voorbeelden en opmerkingen zijn
+          <a href="#dfn-informatief" class="internalDFN" data-link-type="dfn">informatief</a>
+          (niet-normatief). Niet-normatief materiaal geeft advies en informatie
+          over het interpreteren van de richtlijnen, maar schrijft geen eisen
+          voor die gevolgen hebben voor een conformiteitsclaim.
+        </p>
+        <p>
+          De belangrijke woorden MOGEN, MOETEN, MOETEN NIET, NIET AANBEVOLEN,
+          AANBEVOLEN, ZOUDEN MOETEN en ZOUDEN NIET MOETEN, moeten worden
+          geïnterpreteerd zoals beschreven in [<cite><a class="bibref" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels" data-link-type="biblio">RFC2119</a></cite>].
+        </p>
+      </section>
+
+      <section id="conformiteitseisen">
+        <h3 id="x5-2-conformiteitseisen">
+          <bdi class="secno">5.2 </bdi>Conformiteitseisen<a class="self-link" aria-label="§" href="#conformiteitseisen"></a>
+        </h3>
+        <p>
+          Een webpagina is conform WCAG 2.1 als deze aan alle volgende
+          conformiteitseisen voldoet:
+        </p>
+
+        <section id="cc1">
+          <h4 id="x5-2-1-conformiteitsniveau">
+            <bdi class="secno">5.2.1 </bdi>Conformiteitsniveau<a class="self-link" aria-label="§" href="#cc1"></a>
+          </h4>
+          <p>
+            Aan een van de volgende conformiteitsniveaus wordt volledig voldaan:
+          </p>
+          <ul>
+            <li>
+              Voor conformiteit van Niveau A (het minimumniveau van
+              conformiteit)
+              <a href="#dfn-voldoet" class="internalDFN" data-link-type="dfn">voldoet</a>
+              de
+              <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina</a>
+              aan alle succescriteria van Niveau A, of er is een
+              <a href="#dfn-conforme-alternatieve-versie" class="internalDFN" data-link-type="dfn">conforme alternatieve versie</a>
+              beschikbaar.
+            </li>
+            <li>
+              Voor conformiteit van Niveau AA voldoet de webpagina aan alle
+              succescriteria van Niveau A en Niveau AA of er is een conforme
+              alternatieve versie van Niveau AA beschikbaar.
+            </li>
+            <li>
+              Voor conformiteit van Niveau AAA voldoet de webpagina aan alle
+              succescriteria van Niveau A, Niveau AA en Niveau AAA of er is een
+              conforme alternatieve versie van Niveau AAA beschikbaar.
+            </li>
+          </ul>
+
+          <div class="note" role="note" id="issue-container-generatedID-28">
+
+            <div role="heading" class="note-title marker" id="h-note-28" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Hoewel conformiteit alleen op de vermelde niveaus kan worden
+              bereikt, worden auteurs aangemoedigd om (in hun claim) te
+              rapporteren welke vooruitgang ze boeken bij het voldoen aan
+              succescriteria van alle niveaus hoger dan het bereikte niveau van
+              conformiteit.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-29">
+
+            <div role="heading" class="note-title marker" id="h-note-29" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Het is niet aan te bevelen om beleidsmatig conformiteit op Niveau
+              AAA te eisen voor hele sites, omdat het voor sommige content niet
+              mogelijk is om aan alle succescriteria van Niveau AAA te voldoen.
+            </p>
+          </div>
+        </section>
+
+        <section id="cc2">
+          <h4 id="x5-2-2-volledige-pagina-s">
+            <bdi class="secno">5.2.2 </bdi>Volledige pagina's<a class="self-link" aria-label="§" href="#cc2"></a>
+          </h4>
+          <p>
+            <a href="#dfn-conformiteitseisen" class="internalDFN" data-link-type="dfn">Conformiteit</a>
+            (en conformiteitsniveau) is slechts voor volledige
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina(s)</a>
+            en kan niet worden bereikt als een deel van de webpagina wordt
+            uitgesloten.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-30">
+
+            <div role="heading" class="note-title marker" id="h-note-30" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Om de conformiteit te bepalen, worden alternatieven voor een deel
+              van de content van de pagina beschouwd als deel van de pagina als
+              de alternatieven direct uit de pagina verkregen kunnen worden,
+              bijvoorbeeld een lange beschrijving of een alternatieve weergave
+              van een video.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-31">
+
+            <div role="heading" class="note-title marker" id="h-note-31" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Auteurs van webpagina's, die niet kunnen conformeren omdat ze te
+              maken hebben met content waar zij geen zeggenschap over hebben,
+              kunnen een
+              <a href="#verklaring-van-partiele-conformiteit-content-van-derden">verklaring van partiële conformiteit</a>
+              overwegen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-32">
+
+            <div role="heading" class="note-title marker" id="h-note-32" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="new">
+              <span class="change"></span> Een volledige pagina omvat elke
+              variant van die pagina die automatisch door de pagina wordt
+              weergegeven voor verschillende schermgroottes (bijvoorbeeld
+              varianten van een responsieve webpagina). Voor conformiteit van de
+              gehele pagina moeten alle varianten van de pagina conformeren (of
+              er moet een alternatieve versie beschikbaar zijn die conformeert).
+            </p>
+          </div>
+        </section>
+
+        <section id="cc3">
+          <h4 id="x5-2-3-volledige-processen">
+            <bdi class="secno">5.2.3 </bdi>Volledige processen<a class="self-link" aria-label="§" href="#cc3"></a>
+          </h4>
+          <p>
+            Als een
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina</a>
+            één is uit een serie van webpagina's die een
+            <a href="#dfn-processen" class="internalDFN" data-link-type="dfn">proces</a>
+            vormen (d.w.z. een rij stappen die voltooid moet worden om een
+            activiteit tot stand te brengen), conformeren alle webpagina's in
+            het proces aan het gespecificeerde niveau of beter. (Conformiteit is
+            niet mogelijk op een bepaald niveau als om het even welke pagina in
+            het proces niet aan dat niveau of beter conformeert.)
+          </p>
+          <p class="example">
+            Een online warenhuis heeft een serie pagina's die gebruikt worden om
+            producten te selecteren en te kopen. Alle pagina's in de serie van
+            begin tot eind (kassa) conformeren om elke willekeurige pagina die
+            deel van het proces is te laten conformeren.
+          </p>
+        </section>
+
+        <section id="cc4">
+          <h4 id="x5-2-4-louter-door-toegankelijkheid-ondersteunde-manieren-om-technologieen-te-gebruiken">
+            <bdi class="secno">5.2.4 </bdi>
+            Louter door toegankelijkheid ondersteunde manieren om technologieën
+            te gebruiken
+            <a class="self-link" aria-label="§" href="#cc4"></a>
+          </h4>
+          <p>
+            Om te voldoen aan succescriteria wordt gesteund op de
+            beschikbaarheid van louter
+            <a href="#dfn-toegankelijkheid-ondersteund" class="internalDFN" data-link-type="dfn">door toegankelijkheid ondersteunde</a>
+            manieren om
+            <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">technologieën</a>
+            te gebruiken. Elke informatie of functionaliteit die geleverd wordt
+            op een manier die niet door toegankelijkheid ondersteund wordt, is
+            ook beschikbaar op een manier die door toegankelijkheid ondersteund
+            is. (Zie
+            <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding accessibility support</a>.)
+          </p>
+        </section>
+
+        <section id="cc5">
+          <h4 id="x5-2-5-niet-interferentie">
+            <bdi class="secno">5.2.5 </bdi>Niet-interferentie<a class="self-link" aria-label="§" href="#cc5"></a>
+          </h4>
+          <p>
+            Als
+            <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">technologieën</a>
+            gebruikt worden op een manier die niet door
+            <a href="#dfn-toegankelijkheid-ondersteund" class="internalDFN" data-link-type="dfn">toegankelijkheid ondersteund</a>
+            wordt of als ze gebruikt worden op een niet-conforme manier, dan
+            blokkeren ze niet het vermogen van de gebruiker om de rest van de
+            pagina te bereiken. Bovendien blijft de
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina</a>
+            als geheel voldoen aan de conformiteitseisen onder elk van de
+            volgende voorwaarden:
+          </p>
+          <ol>
+            <li>
+              als om het even welke technologie waarop niet
+              <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">gesteund wordt</a>, is aangezet in een user agent,
+            </li>
+            <li>
+              als om het even welke technologie waarop niet gesteund wordt, is
+              uitgezet in een user agent,
+            </li>
+            <li>
+              als om het even welke technologie waarop niet gesteund wordt, niet
+              ondersteund wordt door een user agent.
+            </li>
+          </ol>
+          <p>
+            Verder zijn de volgende succescriteria van toepassing op alle
+            content op de pagina, met inbegrip van content waarop niet op een
+            andere manier gesteund wordt om te voldoen aan conformiteit, omdat
+            content die niet aan deze criteria voldoet elk gebruik van de pagina
+            kan belemmeren:
+          </p>
+          <ul>
+            <li><strong>1.4.2 - Geluidsbediening</strong>,</li>
+            <li><strong>2.1.2 - Geen toetsenbordval</strong>,</li>
+            <li>
+              <strong>2.3.1 - Drie flitsen of beneden drempelwaarde</strong>, en
+            </li>
+            <li><strong>2.2.2 - Pauzeren, stoppen, verbergen</strong>.</li>
+          </ul>
+
+          <div class="note" role="note" id="issue-container-generatedID-33">
+
+            <div role="heading" class="note-title marker" id="h-note-33" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als een pagina niet kan conformeren (bijvoorbeeld, een
+              conformiteitstest pagina of een voorbeeldpagina), kan ze niet
+              worden meegenomen binnen de scope van de conformiteit of in een
+              conformiteitsclaim.
+            </p>
+          </div>
+          <p>
+            Voor meer informatie, inclusief voorbeelden zie
+            <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance Requirements</a>.
+          </p>
+        </section>
+      </section>
+
+      <section id="conformiteitsclaims">
+        <h3 id="x5-3-conformiteitsclaims-optioneel">
+          <bdi class="secno">5.3 </bdi>Conformiteitsclaims (optioneel)<a class="self-link" aria-label="§" href="#conformiteitsclaims"></a>
+        </h3>
+        <p>
+          Conformiteit is alleen gedefinieerd voor
+          <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>. Er kan evenwel een conformiteitsclaim gemaakt worden voor één
+          pagina, voor een serie pagina's of voor meerdere verwante webpagina's.
+        </p>
+
+        <section id="vereiste-componenten-van-een-conformiteitsclaim">
+          <h4 id="x5-3-1-vereiste-componenten-van-een-conformiteitsclaim">
+            <bdi class="secno">5.3.1 </bdi>Vereiste componenten van een
+            conformiteitsclaim<a class="self-link" aria-label="§" href="#vereiste-componenten-van-een-conformiteitsclaim"></a>
+          </h4>
+          <p>
+            Conformiteitsclaims zijn <strong>niet verplicht</strong>. Auteurs
+            kunnen conformeren aan WCAG 2.1 zonder hierop aanspraak te maken.
+            Als evenwel een conformiteitsclaim gemaakt wordt, dan
+            <strong>moet</strong> de conformiteitsclaim de volgende informatie
+            bevatten:
+          </p>
+          <ol>
+            <li><strong>Datum</strong> van de claim</li>
+            <li>
+              <strong>Titel, versie en URI</strong> van de richtlijnen "Web
+              Content Accessibility Guidelines 2.1
+              <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>"
+            </li>
+            <li>
+              <strong>Conformiteitsniveau </strong> waaraan voldaan is: (Niveau
+              A, AA of AAA)
+            </li>
+            <li>
+              <p>
+                <strong> Een beknopte beschrijving van de webpagina's</strong>,
+                zoals een lijst van URI's waarvoor de claim is gemaakt,
+                inclusief de informatie of deelgebieden zijn inbegrepen in de
+                claim.
+              </p>
+
+              <div class="note" role="note" id="issue-container-generatedID-34">
+
+                <div role="heading" class="note-title marker" id="h-note-34" aria-level="5">
+                  <span>Noot</span>
+                </div>
+                <p class="">
+                  De webpagina's kunnen beschreven worden door een lijst of door
+                  een expressie die alle in de claim inbegrepen URI's
+                  beschrijft.
+                </p>
+              </div>
+
+              <div class="note" role="note" id="issue-container-generatedID-35">
+
+                <div role="heading" class="note-title marker" id="h-note-35" aria-level="5">
+                  <span>Noot</span>
+                </div>
+                <p class="">
+                  Webgerelateerde producten die geen URI hebben vóór installatie
+                  op de website van de klant kunnen een verklaring hebben dat
+                  het product zou conformeren, indien geïnstalleerd.
+                </p>
+              </div>
+            </li>
+            <li>
+              Een lijst van de
+              <strong>
+                <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">webcontent technologieën</a>
+                <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">waarop wordt gesteund</a> </strong>.
+            </li>
+          </ol>
+
+          <div class="note" role="note" id="issue-container-generatedID-36">
+
+            <div role="heading" class="note-title marker" id="h-note-36" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als een conformiteitslogo wordt gebruikt, zou dat een claim zijn
+              en moet het samengaan met de eerder genoemde componenten van een
+              conformiteitsclaim.
+            </p>
+          </div>
+        </section>
+
+        <section id="optionele-componenten-van-een-conformiteitsclaim">
+          <h4 id="x5-3-2-optionele-componenten-van-een-conformiteitsclaim">
+            <bdi class="secno">5.3.2 </bdi>Optionele componenten van een
+            conformiteitsclaim<a class="self-link" aria-label="§" href="#optionele-componenten-van-een-conformiteitsclaim"></a>
+          </h4>
+          <p>
+            Overweeg, behalve de eerder genoemde vereiste componenten van een
+            conformiteitsclaim, het aanbieden van extra informatie om gebruikers
+            te assisteren. Aanbevolen extra informatie omvat:
+          </p>
+          <ul>
+            <li>
+              Een lijst van succescriteria boven het niveau van
+              conformiteitsclaim waaraan voldaan is. Deze informatie zou
+              aangeboden moeten worden in een vorm die bruikbaar is voor
+              gebruikers, bij voorkeur machine-leesbare metadata.
+            </li>
+            <li>
+              Een lijst van de specifieke technologieën die "<em>gebruikt worden, maar waarop niet
+                <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">gesteund wordt</a> </em>."
+            </li>
+            <li>
+              Een lijst van user agents, met inbegrip van hulptechnologieën die
+              gebruikt zijn om de content te testen.
+            </li>
+            <li class="new">
+              Een lijst van specifieke toegankelijkheidskenmerken van de
+              content, in machine-leesbare metadata.
+            </li>
+            <li>
+              Informatie betreffende extra stappen die zijn genomen om verder
+              dan de succescriteria te gaan om toegankelijkheid te verbeteren.
+            </li>
+            <li>
+              Een machine-leesbare metadataversie van de lijst van specifieke
+              technologieën waarop
+              <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">gesteund wordt</a>.
+            </li>
+            <li>
+              Een machine-leesbare metadataversie van de lijst van de
+              conformiteitsclaim.
+            </li>
+          </ul>
+
+          <div class="note" role="note" id="issue-container-generatedID-37">
+
+            <div role="heading" class="note-title marker" id="h-note-37" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              We verwijzen naar
+              <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance Claims</a>
+              voor meer informatie en voorbeeld conformiteitsclaims.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-38">
+
+            <div role="heading" class="note-title marker" id="h-note-38" aria-level="5">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              We verwijzen naar
+              <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/appendixC">Understanding Metadata</a>
+              voor meer informatie over het gebruik van metadata in
+              conformiteitsclaims.
+            </p>
+          </div>
+        </section>
+      </section>
+
+      <section id="verklaring-van-partiele-conformiteit-content-van-derden">
+        <h3 id="x5-4-verklaring-van-partiele-conformiteit-content-van-derden">
+          <bdi class="secno">5.4 </bdi>Verklaring van partiële conformiteit –
+          Content van derden<a class="self-link" aria-label="§" href="#verklaring-van-partiele-conformiteit-content-van-derden"></a>
+        </h3>
+        <p>
+            Webpagina's waaraan later aanvullende content wordt toegevoegd kunnen een ‘verklaring van partiële conformiteit’ gebruiken. Bijvoorbeeld een e-mailprogramma, een blog, een artikel dat gebruikers toestaat commentaar toe te voegen of applicaties die door de gebruiker bijgedragen content ondersteunen. Nog een voorbeeld zou een pagina zijn, zoals een portal of een nieuwssite, die is samengesteld uit content die wordt samengesteld vanuit meerdere leveranciers, of websites die automatisch in de loop van tijd content uit andere bronnen invoegen, zoals wanneer advertenties dynamisch worden ingevoegd. 
+        </p>
+        <p>
+          In deze gevallen is het niet mogelijk om op het tijdstip van de
+          oorspronkelijke bijdrage te weten wat de niet-gecontroleerde content
+          van de pagina's zal zijn. Het is belangrijk op te merken dat de
+          niet-gecontroleerde content ook de toegankelijkheid van de
+          gereguleerde content kan beïnvloeden. Twee opties zijn beschikbaar:
+        </p>
+        <ol>
+          <li>
+            <p>
+              Conformiteit kan worden vastgesteld naar beste weten. Als een
+              pagina van dit type binnen twee werkdagen wordt gemonitord en
+              gerepareerd (niet-conforme content wordt verwijderd of conform
+              gemaakt), dan kan een besluit tot conformiteitsclaim worden
+              gemaakt aangezien de pagina conformeert, op fouten in extern
+              bijgedragen content na, die verwijderd of verbeterd worden als ze
+              worden aangetroffen. Geen conformiteitsclaim kan worden gemaakt
+              als het niet mogelijk is om niet-conforme content te monitoren of
+              te verbeteren;
+            </p>
+            <p>
+              <strong> OF</strong>
+            </p>
+          </li>
+          <li>
+            <p>
+              Een "verklaring van partiële conformiteit" kan worden gemaakt: de
+              pagina conformeert niet, maar zou kunnen conformeren als zekere
+              onderdelen verwijderd zouden worden. De formulering van de
+              verklaring zou zijn: "Deze pagina conformeert niet maar zou aan
+              WCAG 2.2 conformeren op niveau X als de volgende onderdelen
+              afkomstig uit niet gecontroleerde bronnen verwijderd werden."
+              Verder zou het volgende ook waar zijn van niet-gecontroleerde
+              content die beschreven wordt in de verklaring van partiële
+              conformiteit:
+            </p>
+            <ol>
+              <li>
+                Het is geen content waar de auteur zeggenschap over heeft.
+              </li>
+              <li>
+                Ze wordt beschreven op een manier die gebruikers kunnen
+                identificeren (ze kunnen bijvoorbeeld niet beschreven worden als
+                "alle onderdelen waar wij geen zeggenschap over hebben", tenzij
+                ze duidelijk als zodanig zijn gemarkeerd).
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+
+      <section id="verklaring-van-partiele-conformiteit-taal">
+        <h3 id="x5-5-verklaring-van-partiele-conformiteit-taal">
+          <bdi class="secno">5.5 </bdi>Verklaring van partiële conformiteit –
+          Taal<a class="self-link" aria-label="§" href="#verklaring-van-partiele-conformiteit-taal"></a>
+        </h3>
+        <p>
+          Een "Verklaring van partiële conformiteit vanwege taal" kan worden
+          afgegeven als de pagina niet conformeert, maar zou conformeren als
+          <a href="#dfn-toegankelijkheid-ondersteund" class="internalDFN" data-link-type="dfn">toegankelijkheidsondersteuning</a>
+          bestond voor de taal (elk van de talen) die op de pagina gebruikt
+          worden. De formulering van die verklaring zou zijn: "Deze pagina
+          conformeert niet, maar zou aan WCAG 2.2 conformeren op niveau X als
+          toegankelijkheidsondersteuning bestond voor de volgende taal (talen):"
+        </p>
+      </section>
+
+      <section class="informative" id="privacy-summary"><div class="header-wrapper"><h3 id="x5-6-privacy-considerations"><bdi class="secno">5.6 </bdi>Privacyoverwegingen</h3><a class="self-link" href="#privacy-summary" aria-label="Permalink for Section 5.6"></a></div><p><em>Deze paragraaf is niet-normatief. </em></p>
+            
+            
+            
+        <p>Succescriteria binnen deze specificatie waarvoor de Werkgroep mogelijke privacy implicaties heeft geïdentificeerd, hetzij door bescherming te bieden aan eindgebruikers, hetzij doordat het belangrijk is voor aanbieders van websites om rekening mee te houden bij het implementeren van functies die bedoeld zijn om de privacy van gebruikers te beschermen, worden hieronder vermeld. Deze lijst weerspiegelt het huidige begrip van de Werkgroep, maar er kunnen andere succescriteria zijn met privacy implicaties waar de Werkgroep zich op het moment van publicatie niet van bewust was.
+        </p>
+        
+        <p>Succescriteria binnen deze specificatie die mogelijk verband houden met privacy zijn: </p>
+        
+        <ul>
+           
+           <li><a href="#timeouts">2.2.6 Time-outs (AAA)</a></li>
+           
+           <li><a href="#redundant-entry">3.3.7 Overbodige invoer (A)</a></li>
+           
+        </ul>
+        
+        
+     </section>
+
+     <section class="informative" id="security-summary"><div class="header-wrapper"><h3 id="x5-7-security-considerations"><bdi class="secno">5.7 </bdi>Securityoverwegingen</h3><a class="self-link" href="#security-summary" aria-label="Permalink for Section 5.7"></a></div><p><em>Dit onderdeel is niet-normatief.</em></p>
+            
+            
+            
+        <p>Succescriteria binnen deze specificatie waarvoor de Werkgroep mogelijke security implicaties heeft geïdentificeerd, hetzij door bescherming te bieden aan eindgebruikers, hetzij doordat het belangrijk is voor aanbieders van websites om rekening mee te houden bij het implementeren van functies die bedoeld zijn om de security van gebruikers te beschermen, worden hieronder vermeld. Deze lijst weerspiegelt het huidige begrip van de Werkgroep, maar er kunnen andere succescriteria zijn met security-implicaties waar de Werkgroep zich op het moment van publicatie niet van bewust was. 
+        </p>
+        
+        <p>Succescriteria binnen deze specificatie die mogelijk verband houden met security zijn: </p>
+        
+        <ul>
+           
+           <li><a href="#non-text-content">1.1.1 Niet-tekstuele content (A)</a></li>
+           
+           <li><a href="#identify-input-purpose">1.3.5 Identificeer het doel van de input (AA)</a></li>
+           
+           <li><a href="#low-or-no-background-audio">1.4.7 Weinig of geen achtergrondgeluid (AAA)</a></li>
+           
+           <li><a href="#timing-adjustable">2.2.1 Timing aanpasbaar (A)</a></li>
+           
+           <li><a href="#re-authenticating">2.2.5 Herauthentisering (AAA)</a></li>
+           
+           <li><a href="#timeouts">2.2.6 Time-outs (AAA)</a></li>
+           
+           <li><a href="#concurrent-input-mechanisms">2.5.6 Input gelijktijdige invoermechanismen (AAA)</a></li>
+           
+           <li><a href="#error-suggestion">3.3.3 Foutsuggestie (AA)</a></li>
+           
+           <li><a href="#redundant-entry">3.3.7 Overbodige invoer (A)</a></li>
+           
+           <li><a href="#accessible-authentication-minimum">3.3.8 Toegankelijke authenticatie (minimum) (AA)</a></li>
+           
+           <li><a href="#accessible-authentication-enhanced">3.3.9 Toegankelijke authenticatie (uitgebreid) (AAA)</a></li>                    
+           
+        </ul>
+        
+     </section>
+    </section>
+
+    <section id="verklarende-woordenlijst">
+      <h2 id="x6-verklarende-woordenlijst">
+        <bdi class="secno">6. </bdi>Verklarende woordenlijst<a class="self-link" aria-label="§" href="#verklarende-woordenlijst"></a>
+      </h2>
+
+      <dt class="new"><dfn data-lt="cognitive function test|Cognitive function test" id="dfn-cognitive-function-test" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">cognitieve functietest</dfn></dt>
+
+      <dd class="new">
+   					
+        <p class="change">[Nieuw]</p>
+                            
+        <p>Een taak waarbij de gebruiker informatie moet onthouden, bewerken of uitschrijven. Voorbeelden omvatten, maar zijn niet beperkt tot:</p>
+        <ul>
+            <li>Memoriseren, zoals het onthouden van een gebruikersnaam, wachtwoord, reeks tekens, afbeeldingen of patronen. Gangbare identificatoren zoals naam, e-mail en telefoonnummer worden niet beschouwd als cognitieve functietests, omdat ze persoonlijk zijn voor de gebruiker en consistent over verschillende websites; </li>
+            <li>Transcriptie, zoals het intypen van tekens;</li>
+            <li>Gebruik van correcte spelling;</li>
+            <li>Uitvoeren van berekeningen;</li>
+            <li>Oplossen van puzzels.</li>
+         </ul>
+         
+     </dd>
+
+     <dt class="new"><dfn data-lt="dragging movements|dragging movement" id="dfn-dragging-movements" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">sleepbeweging</dfn></dt>
+
+     <dd class="new">
+        <p class="change">[Nieuw]</p>
+                           
+      <p>Een handeling waarbij de aanwijzer contact maakt met een element tijdens het indrukken van de knop <a href="#dfn-down-event" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-down-event-2" title="platform event that occurs when the trigger stimulus of a pointer is depressed">(down-event)</a> en het element (of een weergave van de positie ervan) de aanwijzer volgt totdat de knop wordt losgelaten <a href="#dfn-up-event" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-up-event-2" title="platform event that occurs when the trigger stimulus of a pointer is released">(up-event).</a></p>
+       
+       <div class="note" role="note" id="issue-container-generatedID-97"><div role="heading" class="note-title marker" id="h-note-97" aria-level="3"><span>Note</span></div><p class="">Voorbeelden van versleepbare elementen zijn lijstitems, tekstelementen en afbeeldingen.</p></div>
+    </dd>
+
+
+    <dt class="new"><dfn data-lt="enclose|encloses" id="dfn-enclose" tabindex="0" aria-haspopup="dialog" class="respec-offending-element" title="Found definition for &quot;encloses&quot;, but nothing links to it. This is usually a spec bug!" data-dfn-type="dfn">omsluitend</dfn></dt>
+
+    <dd class="new">
+        <p class="change">[Nieuw]</p>
+                           
+       <p>aaneengesloten begrensd of omringd.</p>
+                       
+    </dd>
+
+
+    <dt class="new"><dfn id="dfn-focus-indicator" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">focusindicator</dfn></dt>
+
+    <dd class="new">
+        <p class="change">[Nieuw]</p>	
+    
+       <p>pixels die veranderen om visueel aan te geven dat een <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-14" title="a part of the content that is perceived by users as a single control for a distinct function">componenten van de gebruikersinterface</a>  de focus heeft. <a href="#dfn-states" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-states-2" title="dynamic property expressing characteristics of a user interface component that may change in response to user action or automated processes"></a>
+    
+        </p>
+                       
+    </dd>
+
+
+    <dt class="new"><dfn data-lt="bounding boxes|minimum bounding box" data-plurals="bounding box" id="dfn-bounding-boxes" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">minimale begrenzingskader</dfn></dt>
+
+    <dd class="new">
+        <p class="change">[Nieuw]</p>	
+       <p>de kleinste omsluitende rechthoek die is uitgelijnd op de horizontale as en waarin alle punten van een vorm liggen. Voor componenten die, als onderdeel van een zin of blok tekst (zoals hyperlinks) over meerdere regels lopen, is het begrenzingskader gebaseerd op hoe de component eruit zou zien op een enkele regel. </p>
+    </dd>
+
+
+    <dt class="new"><dfn id="dfn-perimeter" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">omtrek</dfn></dt>
+    <dd class="new">
+        <p class="change">[Nieuw]</p>	
+       <p>doorlopende lijn als begrenzing van vorm, exclusief gedeelde pixels, of het <a href="#dfn-bounding-boxes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-bounding-boxes-2" title="[New]">minimale begrenzingskader</a>, afhankelijk van wat korter is.</p>
+      <aside class="example" id="example-16"><div class="marker">Voorbeeld</div><p>De omtrekberekening voor een 2 CSS-pixel omtrek rond een rechthoek is 4<em>h</em>+4<em>w</em>, waar <em>h</em> de hoogte is en <em>w</em> de breedte. Voor een 2 CSS-pixel omtrek rond een cirkel is het 4𝜋<em>r</em>.</p></aside>
+    </dd>
+
+
+
+      <dl id="terms">
+        <dt>
+          <dfn data-lt="supplementary content|aanvullende content" data-dfn-type="dfn" id="dfn-supplementary-content">aanvullende content</dfn>
+        </dt>
+        <dd>
+          <p>
+            aanvullende
+            <a href="#dfn-webcontent" class="internalDFN" data-link-type="dfn">content</a>
+            die de primaire content illustreert of verduidelijkt
+          </p>
+
+          <p class="example">
+            Een audioversie van een
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina</a>.
+          </p>
+
+          <p class="example">
+            Een illustratie van een complex
+            <a href="#dfn-processen" class="internalDFN" data-link-type="dfn">proces</a>.
+          </p>
+
+          <p class="example">
+            Een alinea die een samenvatting geeft van de belangrijkste
+            uitkomsten en aanbevelingen van een onderzoekstudie.
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="pointer inputs|aanwijzerinvoer" data-dfn-type="dfn" id="dfn-pointer-inputs">aanwijzerinvoer</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            invoerapparaat dat een specifieke coördinaat (of een reeks
+            coördinaten) op een scherm kan aanwijzen, zoals een muis, pen of
+            aanraking.
+          </p>
+
+          <p>
+            Zie ook
+            <a href="https://www.w3.org/TR/pointerevents/#dfn-pointer">Definitie aanwijzergebeurtenissen</a>
+            [<cite><a class="bibref" href="#bib-pointerevents" title="Pointer Events" data-link-type="biblio">pointerevents</a></cite>].
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="afbeeldingen van tekst zijn|afbeeldingen van tekst" data-dfn-type="dfn" id="dfn-afbeeldingen-van-tekst-zijn">afbeeldingen van tekst</dfn>
+        </dt>
+        <dd>
+          <p>
+            tekst die in niet-tekstuele vorm (bijvoorbeeld een afbeelding) is
+            weergegeven om een bijzonder visueel effect te realiseren
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-39">
+
+            <div role="heading" class="note-title marker" id="h-note-39" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">Tekst</a>
+              die onderdeel is van een afbeelding die significant andere visuele
+              content bevat, valt hier niet onder.
+            </p>
+          </div>
+
+          <p class="example">Iemands naam op een naamkaartje in een foto.</p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="abbreviations|afkortingen" data-dfn-type="dfn" id="dfn-abbreviations">afkortingen</dfn>
+        </dt>
+        <dd>
+          <p>
+            verkorte vorm van een woord, zin of naam waar de afkorting geen deel
+            van de taal is geworden
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-40">
+
+            <div role="heading" class="note-title marker" id="h-note-40" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Hier zijn inbegrepen letterwoorden en acroniemen waarbij:
+            </p>
+          </div>
+
+          <ol>
+            <li>
+              <p>
+                <strong>letterwoorden</strong> verkorte vormen zijn van een naam
+                of zin die zijn samengesteld uit de beginletters van woorden of
+                lettergrepen die in die naam of zin bevat zijn
+              </p>
+
+              <div class="note" role="note" id="issue-container-generatedID-41">
+
+                <div role="heading" class="note-title marker" id="h-note-41" aria-level="3">
+                  <span>Noot</span>
+                </div>
+                <p class="">
+                  Niet gedefinieerd in alle talen.
+                </p>
+              </div>
+
+              <p class="example">
+                SNCF is een Frans letterwoord dat de beginletters bevat van de
+                <span lang="fr">Société Nationale des Chemins de Fer</span>, de
+                Franse nationale spoorwegen.
+              </p>
+
+              <p class="example">
+                ESP is een letterwoord voor extra-zintuiglijke perceptie
+                (extrasensory perception).
+              </p>
+            </li>
+
+            <li>
+              <p>
+                <strong>acroniemen</strong> zijn afgekorte vormen die zijn
+                samengesteld uit de beginletters of delen van andere woorden (in
+                een naam of zin) die soms uitgesproken worden als een woord
+              </p>
+
+              <p class="example">
+                NOAA is een acroniem dat samengesteld is uit de beginletters van
+                de National Oceanic and Atmospheric Administration in de
+                Verenigde Staten.
+              </p>
+            </li>
+          </ol>
+
+          <div class="note" role="note" id="issue-container-generatedID-42">
+
+            <div role="heading" class="note-title marker" id="h-note-42" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Sommige bedrijven hebben wat ooit een letterwoord was aangenomen
+              als hun bedrijfsnaam. In deze gevallen is de nieuwe naam van het
+              bedrijf de letters (bijvoorbeeld Ecma) en het woord wordt niet
+              langer beschouwd als een afkorting
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-algemene-flits-en-rodeflitsdrempelwaarden">algemene flits- en rodeflitsdrempelwaarden</dfn>
+        </dt>
+        <dd>
+          <p>
+            een
+            <a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">flits</a>
+            of snel veranderende beeldvolgorde is beneden de drempel (d.w.z. de
+            content komt <strong>door</strong> de controle heen) als een van het
+            volgende waar is:
+          </p>
+
+          <ol>
+            <li>
+              er zijn niet meer dan drie <strong>algemene flitsen</strong> en/of
+              niet meer dan drie <strong>rode flitsen</strong> binnen elke
+              periode van één seconde; of
+            </li>
+
+            <li>
+              het totale oppervlak van gelijktijdig optredende flitsen beslaat
+              niet meer dan in totaal 0,006 steradialen binnen elk segment van
+              10 graden van het visueel veld op het scherm (25% van elk segment
+              van 10 graden van het visueel veld op het scherm) op gangbare
+              kijkafstand
+            </li>
+          </ol>
+
+          <p>waar:</p>
+
+          <ul>
+            <li>
+              Een <strong>algemene flits</strong> gedefinieerd is als een koppel
+              tegengestelde veranderingen in de
+              <a href="#dfn-relatieve-luminantie" class="internalDFN" data-link-type="dfn">relatieve luminantie</a>
+              van 10% of meer van de maximum relatieve luminantie waar de
+              relatieve luminantie van de donkerste afbeelding beneden 0,80 is;
+              en waar "een koppel tegengestelde veranderingen" een stijging is
+              gevolgd door een daling, of een daling gevolgd door een stijging,
+              en
+            </li>
+
+            <li>
+              Een <strong>rode flits</strong> is gedefinieerd als een paar
+              tegengestelde overgangen waaronder één naar verzadigd rood.
+            </li>
+          </ul>
+
+          <p>
+            <em>Uitzondering:</em> Het flitsen van een fijnmazig en evenwichtig
+            patroon zoals witte ruis of een alternerend schaakbordpatroon met
+            "vierkanten" kleiner dan 0,1 graad (van het visuele veld op
+            karakteristieke kijkafstand) op een kant is niet in strijd met de
+            drempelwaarden.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-43">
+
+            <div role="heading" class="note-title marker" id="h-note-43" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Voor algemene software of webcontent zal, als de content wordt
+              bekeken op een scherm van 1024 x 768 pixels, een rechthoek van 341
+              x 256 pixels op een willekeurige plek op het beeldscherm een goede
+              schatting zijn voor een visueel veld van 10 graden voor standaard
+              schermafmetingen en kijk afstanden (bijvoorbeeld een scherm van
+              15-17 inch op een kijkafstand van 22-26 inch). (Beeldschermen met
+              een hogere resolutie die dezelfde weergave van de content vertonen
+              leveren kleinere en veiliger beelden op, dus het zijn lagere
+              resoluties die gebruikt worden om de drempels te definiëren).
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-44">
+
+            <div role="heading" class="note-title marker" id="h-note-44" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een overgang is de verandering in relatieve luminantie (of
+              relatieve luminantie/kleur voor rode flitsen) tussen naast elkaar
+              liggende pieken en dalen in een grafiek van de meting van
+              relatieve luminantie (of relatieve luminantie/kleur voor rode
+              flitsen) tegen de tijd. Een flits bestaat uit twee tegengestelde
+              overgangen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-45">
+
+            <div role="heading" class="note-title marker" id="h-note-45" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De nieuwe werkdefinitie in de branche voor
+              <strong>"tegengestelde overgangen, waaronder naar een verzadigd
+                rood"</strong>
+              (uit WCAG 2.2) is een tegengestelde overgang waarbij 1 transitie van of naar een status is met een waarde R/(R + G + B) ≥ 0,8, en waarbij het verschil tussen de statussen groter is dan 0,2 (eenheidsloos) in het CIE UCS chromaticiteitdiagram.
+              <cite><a class="bibref" data-link-type="biblio" href="#bib-iso_9241-391" title="Ergonomics of human-system interaction—Part 391: Requirements, analysis and compliance test methods for the reduction of photosensitive seizures">[ISO_9241-391]</a></cite>
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-46">
+
+            <div role="heading" class="note-title marker" id="h-note-46" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Er zijn instrumenten beschikbaar die een analyse zullen uitvoeren
+              van schermopnames. Er is evenwel geen instrument noodzakelijk voor
+              deze voorwaarde als het flitsen kleiner of gelijk is aan 3 flitsen
+              per seconde. Content komt automatisch door de controle (zie #1 en
+              #2 hierboven).
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-alternatief-geleverd-voor-op-tijd-gebaseerde-media">alternatief geleverd voor op tijd gebaseerde media</dfn>
+        </dt>
+        <dd>
+          <p>
+            document dat in correcte volgorde gegeven tekstbeschrijvingen van op
+            tijd gebaseerde visuele en auditieve informatie bevat en een middel
+            aanbiedt om de uitkomsten van om het even welke op tijd gebaseerde
+            interactie te realiseren
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-47">
+
+            <div role="heading" class="note-title marker" id="h-note-47" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een scenario dat gebruikt wordt om de
+              gesynchroniseerde-media-content te creëren zou alleen aan deze
+              definitie voldoen als het verbeterd werd om de uiteindelijke
+              gesynchroniseerde media na editing accuraat te representeren.
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-ascii-art">ASCII-art</dfn></dt>
+        <dd>
+          <p>
+            afbeelding die gecreëerd wordt door een ruimtelijke schikking van
+            karakters of tekens (met name uit de 95 afdrukbare karakters
+            gedefinieerd door ASCII)
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-audio">audio</dfn></dt>
+        <dd>
+          <p>
+            de technologie van geluidsweergave
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-48">
+
+            <div role="heading" class="note-title marker" id="h-note-48" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Audio kan synthetisch worden gecreëerd (met inbegrip van
+              spraaksynthese), opgenomen vanuit echte geluiden of beide.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="audio descriptions|audiodescriptie" data-dfn-type="dfn" data-plurals="audiodescripties" id="dfn-audio-descriptions">audiodescriptie</dfn>
+        </dt>
+        <dd>
+          <p>
+            gesproken tekst die is toegevoegd aan het geluidsspoor om
+            belangrijke visuele details te beschrijven, die niet vanuit het
+            hoofdgeluid alleen zijn te begrijpen
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-49">
+
+            <div role="heading" class="note-title marker" id="h-note-49" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Audiodescriptie van
+              <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>
+              levert informatie over handelingen, personages,
+              sceneveranderingen, tekst op het scherm en andere visuele content.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-50">
+
+            <div role="heading" class="note-title marker" id="h-note-50" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Bij standaard audiodescriptie wordt de gesproken tekst toegevoegd
+              tijdens bestaande pauzes in de dialoog. (Zie ook
+              <a href="#dfn-verlengde-audiodescriptie" class="internalDFN" data-link-type="dfn">verlengde audiodescriptie</a>.)
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-51">
+
+            <div role="heading" class="note-title marker" id="h-note-51" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Waar alle
+              <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>-informatie al aangeboden wordt in bestaande
+              <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>, is geen aanvullende audiodescriptie nodig.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-52">
+
+            <div role="heading" class="note-title marker" id="h-note-52" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Wordt ook wel "videobeschrijving" genoemd.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="primary education|basisonderwijsniveau" data-dfn-type="dfn" id="dfn-primary-education">basisonderwijsniveau</dfn>
+        </dt>
+        <dd>
+          <p>
+            periode van zes jaar die begint tussen vijf en zeven jaar, mogelijk
+            zonder enige vooropleiding
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-53">
+
+            <div role="heading" class="note-title marker" id="h-note-53" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze definitie is gebaseerd op de International Standard
+              Classification of Education van de [<cite><a class="bibref" href="#bib-unesco" title="International Standard Classification of Education" data-link-type="biblio">UNESCO</a></cite>].
+            </p>
+          </div>
+        </dd>
+
+        <dt class="new">
+          <dfn data-dfn-type="dfn" id="dfn-bewegingsanimatie">bewegingsanimatie</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            de toevoeging van stappen tussen stadia om de illusie van beweging
+            of het gevoel van een soepele overgang te creëren
+          </p>
+
+          <aside class="example" id="example-16"><div class="marker">Voorbeeld</div>
+            <p>Bijvoorbeeld, een element dat op zijn plaats beweegt of dat groter
+            of kleiner wordt terwijl het verschijnt, wordt beschouwd als een
+            animatie. Een element dat zonder overgang, direct wordt weergegeven,
+            wordt niet als een animatie beschouwd. Een verandering van kleur,
+            vervaging of ondoorzichtigheid wordt niet als bewegingsanimatie
+            beschouwd.</p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-captcha">CAPTCHA</dfn></dt>
+        <dd>
+          <p>
+            letterwoord voor "Completely Automated Public Turing test to tell
+            Computers and Humans Apart"
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-54">
+
+            <div role="heading" class="note-title marker" id="h-note-54" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              CAPTCHA-tests vragen vaak aan de gebruiker om tekst in te typen
+              die getoond wordt in een onduidelijk gemaakte afbeelding of door
+              middel van vervormd geluid.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-55">
+
+            <div role="heading" class="note-title marker" id="h-note-55" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een Turing-test is een willekeurig systeem van testen die
+              ontworpen zijn om een mens van een computer te onderscheiden. Ze
+              is genoemd naar de beroemde informaticus Alan Turing. De term werd
+              bedacht door onderzoekers aan de universiteit van Carnegie Mellon.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="user interface components|component van de gebruikersinterface|componenten van de gebruikersinterface" data-dfn-type="dfn" id="dfn-user-interface-components">componenten van de gebruikersinterface</dfn>
+        </dt>
+        <dd>
+          <p>
+            een deel van de content die door gebruikers wordt waargenomen als
+            een enkel bedieningselement voor een duidelijke functie
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-56">
+
+            <div role="heading" class="note-title marker" id="h-note-56" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Meerdere componenten van de gebruikersinterface kunnen
+              geïmplementeerd worden als een enkel programmeerbaar element.
+              Componenten zoals hier bedoeld zijn niet gebonden aan
+              programmeertechnieken, maar aan wat de gebruiker waarneemt als
+              aparte bedieningselementen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-57">
+
+            <div role="heading" class="note-title marker" id="h-note-57" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Componenten van de gebruikersinterface omvatten formulierelementen
+              en links, evenals door scripts gegenereerde componenten.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-58">
+
+            <div role="heading" class="note-title marker" id="h-note-58" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Wat hier wordt bedoeld met "component" of "component van de
+              gebruikersinterface" wordt soms ook "element van de
+              gebruikersinterface" genoemd.
+            </p>
+          </div>
+
+          <p class="example">
+            Voorbeeld: Een applet heeft een "bedieningselement" dat gebruikt kan
+            worden om per regel of pagina of op willekeurige wijze door content
+            te bewegen. Aangezien elk van die drie een naam zou moeten hebben en
+            onafhankelijk instelbaar zou moeten zijn, zouden ze elk een
+            "component van de gebruikersinterface" zijn.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-conforme-alternatieve-versie">conforme alternatieve versie</dfn>
+        </dt>
+        <dd>
+          <p>
+            versie die:
+          </p>
+
+          <ol>
+            <li>
+              conformeert op het aangegeven niveau en
+            </li>
+
+            <li>
+              volledig dezelfde informatie en
+              <a href="#dfn-functionaliteit" class="internalDFN" data-link-type="dfn">functionaliteit</a>
+              aanbiedt in dezelfde
+              <a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">menselijke taal</a>
+              en
+            </li>
+
+            <li>
+              even actueel is als de niet-conforme content en
+            </li>
+
+            <li>
+              <p>
+                waarvoor ten minste één van de volgende zaken waar is:
+              </p>
+
+              <ol>
+                <li>
+                  de conforme versie kan bereikt worden vanuit de niet-conforme
+                  pagina via een door
+                  <a href="#dfn-toegankelijkheid-ondersteund" class="internalDFN" data-link-type="dfn">toegankelijkheid ondersteund</a>
+                  <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>, of
+                </li>
+
+                <li>
+                  de niet-conforme versie kan slechts bereikt worden vanuit de
+                  conforme versie of
+                </li>
+
+                <li>
+                  de niet-conforme versie kan slechts bereikt worden vanuit een
+                  conforme pagina die ook een mechanisme levert om de conforme
+                  versie te bereiken
+                </li>
+              </ol>
+            </li>
+          </ol>
+
+          <div class="note" role="note" id="issue-container-generatedID-59">
+
+            <div role="heading" class="note-title marker" id="h-note-59" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              In deze definitie betekent "kan slechts bereikt worden" dat er een
+              mechanisme is, zoals een conditionele verwijzing, die de gebruiker
+              verhindert de niet conforme versie te "bereiken" ("laden"), tenzij
+              de gebruiker direct via de conforme versie is gekomen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-60">
+
+            <div role="heading" class="note-title marker" id="h-note-60" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De alternatieve versie hoeft niet pagina voor pagina overeen te
+              stemmen met het origineel (de conforme alternatieve versie kan
+              bijvoorbeeld bestaan uit meerdere pagina's).
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-61">
+
+            <div role="heading" class="note-title marker" id="h-note-61" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als versies in meerdere talen beschikbaar zijn, dan zijn voor elke
+              aangeboden taal conforme alternatieve versies vereist.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-62">
+
+            <div role="heading" class="note-title marker" id="h-note-62" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Er kunnen alternatieve versies geleverd worden om verschillende
+              technologie omgevingen of gebruikersgroepen van dienst te zijn.
+              Elke versie moet zo conform mogelijk zijn. Eén versie zou volledig
+              conform moeten zijn om aan<a href="#cc1">conformiteitseis 1</a>
+              tegemoet te komen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-63">
+
+            <div role="heading" class="note-title marker" id="h-note-63" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De conforme alternatieve versie hoeft zich niet te bevinden binnen
+              de reikwijdte van de conformiteitsverklaring of op dezelfde
+              website, zolang ze even vrijelijk beschikbaar is als de
+              niet-conforme versie.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-64">
+
+            <div role="heading" class="note-title marker" id="h-note-64" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Alternatieve versies moeten niet verward worden met
+              <a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn">aanvullende content</a>, die de oorspronkelijke pagina ondersteunt en de
+              begrijpelijkheid vergroot.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-65">
+
+            <div role="heading" class="note-title marker" id="h-note-65" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Het binnen de content instellen van gebruikersvoorkeuren om een
+              conforme versie te produceren is een acceptabel mechanisme om een
+              andere versie te bereiken, zolang de methode die gebruikt wordt om
+              de voorkeuren in te stellen door toegankelijkheid ondersteund
+              wordt.
+            </p>
+          </div>
+
+          <p>
+            Zie
+            <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conforming Alternate Versions</a>
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="conformiteitseisen|conformeren|conformiteit" data-dfn-type="dfn" id="dfn-conformiteitseisen">conformiteit</dfn>
+        </dt>
+        <dd>
+          <p>
+            voldoen aan alle eisen van een gegeven standaard, richtlijn of
+            specificatie
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="webcontent|content" data-dfn-type="dfn" id="dfn-webcontent">content</dfn>
+          (Webcontent)
+        </dt>
+        <dd>
+          <p>
+            informatie en zintuiglijke ervaring die aan de gebruiker doorgegeven
+            wordt door middel van een
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agent</a>, met inbegrip van code of opmaak die de
+            <a href="#dfn-structuur" class="internalDFN" data-link-type="dfn">structuur</a>,
+            <a href="#dfn-presentatie" class="internalDFN" data-link-type="dfn">presentatie</a>
+            en interacties van de content definieert
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-contextgevoelige-hulp">contextgevoelige hulp</dfn>
+        </dt>
+        <dd>
+          <p>
+            hulptekst die informatie aanbiedt in verband met de functie die
+            momenteel wordt uitgevoerd
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-66">
+
+            <div role="heading" class="note-title marker" id="h-note-66" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Duidelijke labels kunnen dienst doen als contextgevoelige hulp.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="change of context|contextwijzigingen|contextwijziging" data-dfn-type="dfn" id="dfn-change-of-context">contextwijziging</dfn>
+        </dt>
+        <dd>
+          <p>
+            belangrijke veranderingen in de content van
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            die, als ze gemaakt worden zonder dat de gebruiker er bewust van is,
+            gebruikers die niet in staat zijn de hele pagina tegelijkertijd te
+            bekijken kan desoriënteren
+          </p>
+
+          <p>
+            Veranderingen in context zijn onder meer veranderingen van:
+          </p>
+
+          <ol>
+            <li>
+              <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agent</a>;
+            </li>
+
+            <li>
+              <a href="#dfn-weergavekader" class="internalDFN" data-link-type="dfn">weergavekader</a>;
+            </li>
+
+            <li>
+              focus;
+            </li>
+
+            <li>
+              <a href="#dfn-webcontent" class="internalDFN" data-link-type="dfn">content</a>
+              die de betekenis van de webpagina verandert.
+            </li>
+          </ol>
+
+          <div class="note" role="note" id="issue-container-generatedID-67">
+
+            <div role="heading" class="note-title marker" id="h-note-67" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een verandering van content is niet altijd een contextwijziging.
+              Veranderingen in content, zoals een uitklapbare lijst, dynamisch
+              menu of tab-toets bediening veranderen niet noodzakelijk de
+              context, tenzij ze ook één van de bovengenoemde dingen
+              (bijvoorbeeld focus) veranderen.
+            </p>
+          </div>
+
+          <p class="example">
+            Een nieuw venster openen, de focus naar een andere component
+            verplaatsen, naar een nieuwe pagina gaan (waaronder alles wat voor
+            een gebruiker eruit zou zien alsof zij/hij naar een nieuwe pagina
+            was verplaatst) of een significante herordening van de content van
+            een pagina, zijn voorbeelden van contextwijzigingen.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-contrastverhouding">contrastverhouding</dfn>
+        </dt>
+        <dd>
+          <p>(L1 + 0.05) / (L2 + 0.05), waar</p>
+
+          <ul>
+            <li>
+              L1 de
+              <a href="#dfn-relatieve-luminantie" class="internalDFN" data-link-type="dfn">relatieve luminantie</a>
+              van de lichtste van de kleuren is en
+            </li>
+
+            <li>
+              L2 de
+              <a href="#dfn-relatieve-luminantie" class="internalDFN" data-link-type="dfn">relatieve luminantie</a>
+              van de donkerste van de kleuren.
+            </li>
+          </ul>
+
+          <div class="note" role="note" id="issue-container-generatedID-68">
+
+            <div role="heading" class="note-title marker" id="h-note-68" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Contrastverhoudingen kunnen variëren van 1 tot 21 (gewoonlijk
+              geschreven als 1:1 tot 21:1).
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-69">
+
+            <div role="heading" class="note-title marker" id="h-note-69" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Omdat auteurs geen zeggenschap hebben over gebruikersinstellingen
+              met betrekking tot de weergave van tekst (bijvoorbeeld font
+              smoothing en anti-aliasing), kan de contrastverhouding voor tekst
+              worden geëvalueerd terwijl anti-aliasing uitstaat.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-70">
+
+            <div role="heading" class="note-title marker" id="h-note-70" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Ten behoeve van succescriteria 1.4.3 en 1.4.6 wordt het contrast
+              gemeten met betrekking tot de gespecificeerde achtergrond waarop
+              de tekst bij normaal gebruik wordt weergegeven. Indien geen
+              achtergrondkleur is gespecificeerd, wordt verondersteld dat dit
+              wit is.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-71">
+
+            <div role="heading" class="note-title marker" id="h-note-71" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Achtergrondkleur is de gespecificeerde kleur van de content waarop
+              de tekst bij normaal gebruik wordt weergegeven. Het is een fout
+              als wel de kleur van de tekst is gespecificeerd, maar niet de
+              achtergrondkleur, omdat de standaard door de gebruiker gebruikte
+              achtergrondkleur niet bekend is en dus niet kan worden gebruikt om
+              te meten of het contrast volstaat. Om dezelfde reden is het een
+              fout als wel de achtergrondkleur maar niet de tekstkleur is
+              gespecificeerd.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-72">
+
+            <div role="heading" class="note-title marker" id="h-note-72" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als er een rand om de letter is, kan de rand contrast toevoegen en
+              de rand zou gebruikt worden in de berekening van het contrast
+              tussen de letter en zijn achtergrond. Een smalle rand om de letter
+              zou gebruikt worden als letter. Een brede rand om de letter die de
+              inwendige details van de letters invult doet dienst als een halo
+              en zou beschouwd worden als achtergrond.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-73">
+
+            <div role="heading" class="note-title marker" id="h-note-73" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              WCAG-conformiteit moet worden geëvalueerd voor in de content
+              gespecificeerde kleurparen waarvan een auteur zou verwachten dat
+              ze in een karakteristieke presentatie naast elkaar verschijnen.
+              Auteurs hoeven geen ongebruikelijke vormen van presentatie in acht
+              te nemen, zoals door de user agent gemaakte kleurveranderingen,
+              behalve als ze veroorzaakt worden door code van de auteur.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-correcte-leesvolgorde">correcte leesvolgorde</dfn>
+        </dt>
+        <dd>
+          <p>
+            elke sequentie waar woorden en alinea's worden gepresenteerd in een
+            volgorde die de betekenis van de content niet verandert
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="CSS pixels|CSS-pixels" data-dfn-type="dfn" id="dfn-css-pixels">CSS-pixels</dfn>
+        </dt>
+        <dd class="new">
+          <p>visuele hoek van circa 0,0213 graden</p>
+
+          <p>
+            Een CSS-pixel is een gangbare meeteenheid voor alle lengtes en
+            afmetingen in CSS. Deze eenheid is dichtheidsonafhankelijk en
+            verschilt van de werkelijke hardwarepixels in een scherm. User
+            agents en besturingssystemen moeten ervoor zorgen dat de CSS-pixel
+            zo dicht mogelijk bij de
+            <a href="https://www.w3.org/TR/css3-values/#reference-pixel">CSS Values and Units Module Niveau 3 reference pixel</a>
+            [<cite><a class="bibref" href="#bib-css3-values" title="CSS Values and Units Module Level 3" data-link-type="biblio">css3-values</a></cite>] is ingesteld. Deze houdt rekening met de fysieke afmetingen van
+            het scherm en de veronderstelde kijkafstand (factoren die niet
+            kunnen worden bepaald door auteurs van content).
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-dezelfde-functionaliteit">dezelfde functionaliteit</dfn>
+        </dt>
+        <dd>
+          <p>zelfde resultaat indien gebruikt</p>
+
+          <p class="example">
+            Een "zoek"-knop op één webpagina en een "vind"-knop op een andere
+            webpagina kunnen allebei een veld hebben voor het invoeren van een
+            term en het vermelden van onderwerpen in de website die verband
+            houden met de ingevoerde term. In dat geval zouden zij dezelfde
+            functionaliteit hebben, maar niet consistent gelabeld zijn.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-dezelfde-relatieve-volgorde">dezelfde relatieve volgorde</dfn>
+        </dt>
+        <dd>
+          <p>zelfde positie ten opzichte van andere onderdelen</p>
+
+          <div class="note" role="note" id="issue-container-generatedID-74">
+
+            <div role="heading" class="note-title marker" id="h-note-74" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Onderdelen worden geacht in dezelfde relatieve volgorde te zijn,
+              zelfs als andere onderdelen worden ingevoegd of verwijderd uit de
+              oorspronkelijke volgorde. Openklappende navigatiemenu's kunnen
+              bijvoorbeeld een extra detailniveau invoegen of een secundaire
+              navigatieparagraaf kan in de leesvolgorde worden ingevoegd.
+            </p>
+          </div>
+        </dd>
+
+        <dt class="new">
+          <dfn data-dfn-type="dfn" id="dfn-doelgebied">doelgebied</dfn> (target)
+        </dt>
+        <dd class="new">
+          <p>
+            deel van het scherm waar een actie met de aanwijzer kan worden
+            uitgevoerd, zoals een interactief gedeelte van een component van de
+            gebruikersinterface
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-75">
+
+            <div role="heading" class="note-title marker" id="h-note-75" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Wanneer er sprake is van overlapping tussen twee of meer
+              doelgebieden voor aanraken (touch), dan moet het overlappende
+              gedeelte niet worden meegenomen bij het berekenen van de grootte
+              van het doel, tenzij de overlappende doelen dezelfde actie
+              uitvoeren of dezelfde pagina openen.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="programmatically determinable|door software bepaald" data-dfn-type="dfn" id="dfn-programmatically-determinable">door software bepaald</dfn>
+          (door software bepaalbaar)
+        </dt>
+        <dd>
+          <p>
+            bepaald door software uit gegevens die door de auteur op zodanig
+            wijze aangeboden worden dat verschillende
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agents</a>, met inbegrip van
+            <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologieën</a>, deze informatie kunnen oproepen en in verschillende modaliteiten
+            aan gebruikers kunnen tonen.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-76">
+
+            <div role="heading" class="note-title marker" id="h-note-76" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Bepaald in een opmaaktaal uit elementen en attributen die direct
+              gebruikt worden door algemeen beschikbare hulptechnologie.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-77">
+
+            <div role="heading" class="note-title marker" id="h-note-77" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Bepaald uit technologiegebonden gegevensstructuren in een
+              niet-opmaaktaal en aan hulptechnologie getoond via een
+              toegankelijkheid-API die ondersteund wordt door algemeen
+              beschikbare hulptechnologie.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-door-software-bepaalde-linkcontext">door software bepaalde linkcontext</dfn>
+        </dt>
+        <dd>
+          <p>
+            aanvullende informatie die
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            kan worden uit
+            <a href="#dfn-relaties" class="internalDFN" data-link-type="dfn">relaties</a>
+            met een link en die, in combinatie met de linktekst, in
+            verschillende modaliteiten aan de gebruikers wordt gepresenteerd
+          </p>
+
+          <p class="example">
+            In HTML is informatie, die door software bepaalbaar is uit een link
+            in het Engels, de tekst die zich in dezelfde alinea, lijst, of
+            tabelcel bevindt als de link, of de informatie bevindt zich in een
+            tabelkopcel die geassocieerd is met de tabelcel die de link bevat.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-78">
+
+            <div role="heading" class="note-title marker" id="h-note-78" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Aangezien schermlezers leestekens interpreteren, kunnen ze ook de
+              context uit de lopende zin aanbieden wanneer de focus op een link
+              in die zin komt.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-door-software-ingesteld">door software ingesteld</dfn>
+        </dt>
+        <dd>
+          <p>
+            ingesteld door software met gebruikmaking van methoden die
+            ondersteund worden door user agents, met inbegrip van
+            hulptechnologieën
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="toegankelijkheid ondersteund|toegankelijkheidsondersteuning|door toegankelijkheid ondersteunde" data-dfn-type="dfn" id="dfn-toegankelijkheid-ondersteund">door toegankelijkheid ondersteunde</dfn>
+        </dt>
+        <dd>
+          <p>
+            ondersteund door
+            <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologieën</a>
+            van de gebruikers, alsmede door de toegankelijkheidseigenschappen in
+            browsers en andere
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agents</a>
+          </p>
+
+          <p>
+            Om te kwalificeren als een door toegankelijkheid ondersteund gebruik
+            van een webcontent technologie (of eigenschap van een technologie)
+            moet voor een webcontent technologie (of -eigenschap) aan zowel 1
+            als 2 voldaan zijn:
+          </p>
+
+          <ol>
+            <li>
+              <p>
+                <strong>De manier waarop
+                  <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">webcontent technologie</a>
+                  gebruikt wordt, moet ondersteund worden door de
+                  hulptechnologie van de gebruikers.
+                </strong>
+                Dit betekent dat de manier waarop de technologie gebruikt wordt,
+                getest is op interoperabiliteit met de hulptechnologie van de
+                gebruikers in de
+                <a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">menselijke taal</a>
+                (talen) van de content,
+              </p>
+
+              <p>
+                <strong>EN</strong>
+              </p>
+            </li>
+
+            <li>
+              <p>
+                <strong>De webcontent technologie moet door toegankelijkheid
+                  ondersteunde user agents hebben die beschikbaar zijn voor
+                  gebruikers.
+                </strong>
+                Dit betekent dat ten minste één van de vier volgende
+                verklaringen waar is:
+              </p>
+
+              <ol>
+                <li>
+                  <p>
+                    De technologie wordt van nature ondersteund in wijdverbreide
+                    user agents die ook door toegankelijkheid ondersteund worden
+                    (zoals HTML en CSS);
+                  </p>
+
+                  <p>
+                    <strong>OF</strong>
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    De technologie wordt ondersteund in een breed wijdverbreide
+                    plug-in die ook door toegankelijkheid ondersteund wordt;
+                  </p>
+
+                  <p>
+                    <strong>OF</strong>
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    De content is beschikbaar in een gesloten omgeving, zoals
+                    een universiteits- of bedrijfsnetwerk, waar de user agent
+                    die door de technologie wordt vereist en door de organisatie
+                    gebruikt wordt ook door toegankelijkheid ondersteund wordt;
+                  </p>
+
+                  <p>
+                    <strong>OF</strong>
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    De user agent(s) die de technologie ondersteunen worden door
+                    toegankelijkheid ondersteund en zijn beschikbaar voor
+                    download of aanschaf op een manier die:
+                  </p>
+
+                  <ul>
+                    <li>
+                      een persoon met een functiebeperking niet meer kost dan
+                      een persoon zonder functiebeperking
+                      <strong>en</strong>
+                    </li>
+
+                    <li>
+                      even makkelijk is te vinden en te verkrijgen voor een
+                      persoon met functiebeperking als voor een persoon zonder
+                      functiebeperking.
+                    </li>
+                  </ul>
+                </li>
+              </ol>
+            </li>
+          </ol>
+
+          <div class="note" role="note" id="issue-container-generatedID-79">
+
+            <div role="heading" class="note-title marker" id="h-note-79" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De WCAG-werkgroep en het
+              <abbr title="World Wide Web Consortium">W3C</abbr> specificeren
+              niet welke en hoeveel ondersteuning door hulptechnologieën er moet
+              zijn voor het gebruik van een specifieke webtechnologie, zodat die
+              geclassificeerd kan worden als door toegankelijkheid ondersteund.
+              (Zie
+              <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Niveau of Assistive Technology Support Needed for
+                "Accessibility Support"</a>).
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-80">
+
+            <div role="heading" class="note-title marker" id="h-note-80" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Webtechnologieën kunnen gebruikt worden op manieren die niet door
+              toegankelijkheid ondersteund worden, zolang er niet op
+              <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">gesteund wordt</a>
+              en de pagina als geheel tegemoet komt aan de conformiteitseisen,
+              inclusief <a href="#cc4">Conformance Criterion 4</a>: Slechts
+              toegankelijkheid ondersteunende manieren om technologieën te
+              gebruiken en <a href="#cc5">Conformance Criterion 5</a>:
+              Niet-interferentie.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-81">
+
+            <div role="heading" class="note-title marker" id="h-note-81" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als een
+              <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">webtechnologie</a>
+              wordt toegepast op een manier die "door toegankelijkheid
+              ondersteund wordt", houdt dit niet in dat de hele technologie of
+              alle mogelijke toepassingen van de technologie ondersteund worden.
+              De meeste technologieën, inclusief HTML, missen ondersteuning voor
+              ten minste één eigenschap of toepassing. Pagina's zijn alleen
+              conform aan WCAG als er op vertrouwd kan worden dat de toepassing
+              van de door toegankelijkheid ondersteunde technologie voldoet aan
+              de WCAG-eisen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-82">
+
+            <div role="heading" class="note-title marker" id="h-note-82" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als men webcontent technologieën citeert die meerdere versies
+              hebben, dan moet(en) de ondersteunde versie(s) worden
+              gespecificeerd.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-83">
+
+            <div role="heading" class="note-title marker" id="h-note-83" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Eén manier voor auteurs om toepassingen van een technologie te
+              vinden die door toegankelijkheid ondersteund zijn, zou zijn om
+              compilaties van toepassingen te raadplegen die volgens
+              documentatie door toegankelijkheid ondersteund zijn. (Zie
+              <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Accessibility-Supported Web Technology Uses</a>.) Auteurs, bedrijven, technologieaanbieders, of anderen kunnen
+              door toegankelijkheid ondersteunde manieren om webcontent
+              technologieën toe te passen documenteren. Echter alle in de
+              documentatie vermelde manieren om technologieën toe te passen
+              moeten aan de hierboven genoemde definitie van door
+              toegankelijkheid ondersteunde webcontent technologieën voldoen.
+            </p>
+          </div>
+        </dd>
+
+        <dt class="new">
+          <dfn data-dfn-type="dfn" id="dfn-down-event">down-event</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            gebeurtenis die plaatsvindt binnen een platform wanneer de trigger
+            van de aanwijzer wordt ingedrukt
+          </p>
+          <p>
+            Down-event heeft binnen andere platformen mogelijk een andere naam,
+            zoals "touchstart" of "mousedown".
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-dubbelzinnig-voor-gebruikers-in-het-algemeen">dubbelzinnig voor gebruikers in het algemeen</dfn>
+        </dt>
+        <dd>
+          <p>
+            het doel kan niet bepaald worden uit de link en uit alle informatie
+            van de webpagina die aan de gebruiker tegelijkertijd met de link
+            wordt gepresenteerd (d.w.z. lezers zonder functiebeperking zouden
+            niet weten wat een link zou doen tot ze hem activeerden
+          </p>
+
+          <p class="example">
+            Het woord guava in de volgende zin "Eén van de opmerkelijke
+            exportartikelen is guava" is een link. De link zou kunnen leiden
+            naar een definitie van guava, een grafiek die de hoeveelheid
+            geëxporteerde guava weergeeft of een foto van mensen die guava
+            oogsten. Tot de link wordt geactiveerd zijn alle lezers onkundig en
+            de persoon met een functiebeperking wordt op geen enkele wijze
+            benadeeld
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-dfn-type="dfn" id="dfn-enkele-aanwijzer">enkele aanwijzer</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            aanwijzerinvoer waarbij slechts sprake is van één contactpunt op het
+            scherm, zoals eenmaal tikken of klikken, dubbeltikken en -klikken,
+            lang indrukken en padgebaseerde bewegingen.
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-essentieel">essentieel</dfn></dt>
+        <dd>
+          <p>
+            de informatie of functionaliteit van de content zou fundamenteel
+            veranderen indien verwijderd, <strong>en</strong> informatie en
+            functionaliteit kunnen niet bereikt worden op een andere conforme
+            manier
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="flashes|flits" data-dfn-type="dfn" id="dfn-flashes">flits</dfn>
+        </dt>
+        <dd>
+          <p>
+            een koppel tegengestelde veranderingen in de
+            <a href="#dfn-relatieve-luminantie" class="internalDFN" data-link-type="dfn">relatieve luminantie</a>
+            dat toevallen kan veroorzaken bij sommige mensen als de
+            veranderingen groot genoeg zijn en in het juiste frequentiegebied
+            vallen
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-84">
+
+            <div role="heading" class="note-title marker" id="h-note-84" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Zie
+              <a href="#dfn-algemene-flits-en-rodeflitsdrempelwaarden" class="internalDFN" data-link-type="dfn">algemene flits- en rodeflitsdrempelwaarden</a>
+              voor informatie over flitssoorten die niet zijn toegestaan.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-85">
+
+            <div role="heading" class="note-title marker" id="h-note-85" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Zie ook
+              <a href="#dfn-knipperende" class="internalDFN" data-link-type="dfn">knipperen</a>.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-functionaliteit">functionaliteit</dfn>
+        </dt>
+        <dd>
+          <p>
+            <a href="#dfn-processen" class="internalDFN" data-link-type="dfn">processen</a>
+            en resultaten die realiseerbaar zijn door actie van de gebruiker
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-gebarentaal">gebarentaal</dfn></dt>
+        <dd>
+          <p>
+            een taal die combinaties van bewegingen van de handen en de armen,
+            gezichtsuitdrukkingen of lichaamsposities gebruikt om betekenis
+            <em>over</em> te brengen
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-gebarentaalvertolking">gebarentaalvertolking</dfn>
+        </dt>
+        <dd>
+          <p>
+            vertaling van één taal, in het algemeen een gesproken taal, in een
+            <a href="#dfn-gebarentaal" class="internalDFN" data-link-type="dfn">gebarentaal</a>
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-86">
+
+            <div role="heading" class="note-title marker" id="h-note-86" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Echte gebarentalen zijn onafhankelijke talen die niet gerelateerd
+              zijn aan de gesproken taal/talen van hetzelfde land of dezelfde
+              streek.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-gebruikers-bedienbaar">gebruikers bedienbaar</dfn>
+        </dt>
+        <dd>
+          <p>
+            gegevens waarvan de bedoeling is dat ze door gebruikers ingezien en
+            (desgewenst) gewijzigd worden
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-87">
+
+            <div role="heading" class="note-title marker" id="h-note-87" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Dit verwijst niet naar zaken als internetlogs en monitorgegevens
+              van zoekmachines.
+            </p>
+          </div>
+
+          <p class="example">
+            Naam- en adresvelden voor het account van een gebruiker.
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-dfn-type="dfn" id="dfn-gebruikersinactiviteit">gebruikersinactiviteit</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            een aaneengesloten periode waarin geen gebruikersacties plaatsvinden
+          </p>
+          <p>
+            De manier waarop dit wordt bijgehouden, wordt bepaald door de
+            website of applicatie.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="gesteund wordt|waarop wordt gesteund|gesteund worden" data-dfn-type="dfn" id="dfn-gesteund-wordt">gesteund worden</dfn>
+          (technologieën waarop)
+        </dt>
+        <dd>
+          <p>
+            de content zou niet
+            <a href="#dfn-conformiteitseisen" class="internalDFN" data-link-type="dfn">conformeren</a>
+            als die
+            <a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">technologie</a>
+            wordt uitgezet of niet ondersteund wordt
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-gesynchroniseerde-media">gesynchroniseerde media</dfn>
+        </dt>
+        <dd>
+          <p>
+            <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>
+            of
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>
+            gesynchroniseerd met een ander format om informatie te tonen en/of
+            met op tijd gebaseerde interactieve componenten, tenzij de media een
+            <a href="#dfn-media-alternatief-voor-tekst" class="internalDFN" data-link-type="dfn">media-alternatief voor tekst</a>
+            is, die duidelijk als zodanig is gelabeld
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="large-scale|grote" data-dfn-type="dfn" id="dfn-large-scale">grote</dfn>
+          (tekst)
+        </dt>
+        <dd>
+          <p>
+            (tekst) met een lettergrootte van ten minste 18 punt of 14 punt
+            vetgedrukt of een lettergrootte die voor Chinese, Japanse en
+            Koreaanse (CJK) lettertypen een equivalente grootte oplevert
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-88">
+
+            <div role="heading" class="note-title marker" id="h-note-88" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Lettertypen met buitengewoon dunne strepen of ongewone kenmerken
+              en eigenschappen die de herkenbaarheid van hun lettervormen
+              verminderen zijn moeilijker te lezen, in het bijzonder bij lagere
+              contrastniveaus.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-89">
+
+            <div role="heading" class="note-title marker" id="h-note-89" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Lettergrootte is de grootte wanneer de content wordt aangeboden.
+              Het omvat niet het herschalen dat door de gebruiker kan worden
+              gedaan.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-90">
+
+            <div role="heading" class="note-title marker" id="h-note-90" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De feitelijke grootte van het karakter dat de gebruiker ziet, is
+              afhankelijk van zowel de door de auteur gedefinieerde grootte als
+              van het beeldscherm van de gebruiker of de instelling van de user
+              agent. Voor veel gangbare lettertypen is 14- en 18-punts ruwweg
+              equivalent met 1,2 en 1,5 em, of met 120% of 150% van de
+              standaardgrootte voor korpstekst (aannemend dat het
+              hoofdlettertype 100% is), maar auteurs zouden dit moeten
+              controleren voor de specifieke lettertypen die ze gebruiken. Als
+              lettertypen gedefinieerd worden in relatieve eenheden, wordt de
+              feitelijke lettergrootte voor vertoning door de user agent
+              berekend. De lettergrootte moet worden verkregen van de user
+              agent, of berekend op basis van lettertypemetriek, zoals de user
+              agent doet bij de evaluatie van dit succescriterium. Gebruikers
+              die beperkt zicht hebben, zouden verantwoordelijk zijn voor het
+              kiezen van de geschikte instellingen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-91">
+
+            <div role="heading" class="note-title marker" id="h-note-91" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als tekst wordt gebruikt zonder specificatie van de lettergrootte,
+              zou de kleinste lettergrootte die op de meest gangbare browsers
+              voor ongespecificeerde tekst gebruikt wordt een redelijke maat
+              zijn om voor het lettertype aan te nemen. Als een kop van niveau 1
+              wordt weergegeven in 14- of meerpunts vet op de meest gangbare
+              browsers, mag redelijkerwijs worden aangenomen dat het grote tekst
+              is. Relatieve schaling kan op een soortgelijke manier worden
+              berekend uit de standaardmaten.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-92">
+
+            <div role="heading" class="note-title marker" id="h-note-92" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De 18- en 14-punts-lettergroottes voor romeinse teksten worden
+              afgeleid uit de minimumgrootte voor grote letters (14-punts) en de
+              grootste standaardlettergrootte (18-punts). De "equivalente"
+              groottes voor andere lettertypen, zoals de CJK-talen, zouden de
+              minimale grootte voor grote tekst en de daaropvolgende grotere
+              standaardgrootte voor die talen zijn.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="hulptechnologieën|hulptechnologie" data-dfn-type="dfn" id="dfn-hulptechnologieen">hulptechnologie</dfn>
+          (zoals gebruikt in dit document)
+        </dt>
+        <dd>
+          <p>
+            hardware en/of software die handelt als een
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agent</a>, of samen met een algemeen gangbare user agent optreedt, om
+            functionaliteit aan te bieden om te voldoen aan de eisen van
+            gebruikers met functiebeperkingen die verder gaan dan wat door
+            gangbare user agents wordt aangeboden
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-93">
+
+            <div role="heading" class="note-title marker" id="h-note-93" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Door een hulptechnologie aangeboden functionaliteit omvat
+              alternatieve vormen van weergave (bijvoorbeeld als synthetische
+              spraak of vergrote content), alternatieve invoermethoden
+              (bijvoorbeeld stem), aanvullende navigatie- of
+              oriëntatiemechanismen, en contenttransformaties (bijvoorbeeld om
+              tabellen toegankelijker te maken).
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-94">
+
+            <div role="heading" class="note-title marker" id="h-note-94" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Hulptechnologieën communiceren vaak gegevens en boodschappen met
+              algemeen gangbare user agents door APIs te gebruiken en te
+              monitoren.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-95">
+
+            <div role="heading" class="note-title marker" id="h-note-95" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Het verschil tussen algemeen gangbare user agents en
+              hulptechnologieën is niet absoluut. Veel gangbare user agents
+              bieden een aantal opties aan om mensen met een functiebeperking te
+              helpen. Het fundamentele verschil is dat gangbare user agents
+              mikken op brede en diverse doelgroepen die doorgaans mensen met en
+              zonder functiebeperkingen bevatten. Hulptechnologieën mikken op
+              nauwkeurig gedefinieerde bevolkingsgroepen van gebruikers met
+              specifieke functiebeperkingen. De door een hulptechnologie
+              geleverde assistentie is meer specifiek en geschikt voor de
+              behoeften van de beoogde gebruikers. De algemeen gangbare user
+              agent kan belangrijke functionaliteit leveren aan
+              hulptechnologieën als het oproepen van webcontent uit
+              programmaobjecten of het parsen van opmaak tot identificeerbare
+              pakketten.
+            </p>
+          </div>
+
+          <p class="example">
+            Hulptechnologieën die belangrijk zijn in de context van dit document
+            omvatten onder andere:
+          </p>
+
+          <ul>
+            <li>
+              schermvergroters en andere visuele leeshulpmiddelen, die gebruikt
+              worden door mensen met visuele, perceptuele en physical print
+              functiebeperkingen om lettertype, grootte, spatiëring, kleur,
+              synchronisatie met spraak, etc. te veranderen om de visuele
+              leesbaarheid van de weergegeven tekst en afbeeldingen te
+              verbeteren;
+            </li>
+
+            <li>
+              schermlezers, die gebruikt worden door mensen die blind zijn om
+              tekstuele informatie te lezen door middel van synthetische spraak
+              of braille;
+            </li>
+
+            <li>
+              software die tekst in synthetische spraak omzet, gebruikt door
+              mensen met cognitieve, taal- en leermoeilijkheden;
+            </li>
+
+            <li>
+              spraakherkenningsoftware, die gebruikt kan worden door mensen met
+              bepaalde fysieke functiebeperkingen;
+            </li>
+
+            <li>
+              alternatieve toetsenborden, die gebruikt worden door mensen met
+              bepaalde fysieke functiebeperkingen om het toetsenbord te
+              simuleren (met inbegrip van alternatieve toetsenborden die "head
+              pointers", eenknopsschakelaars, zuig-/blaasschakelaars en andere
+              speciale invoerapparatuur gebruiken);
+            </li>
+
+            <li>
+              alternatieve aanwijsapparaten, die gebruikt worden door mensen met
+              zekere fysieke functiebeperkingen om muisaanwijzing en
+              knopactiveringen te simuleren.
+            </li>
+          </ul>
+        </dd>
+
+        <dt>
+          <dfn data-lt="idioms|idiomatische uitdrukkingen" data-dfn-type="dfn" id="dfn-idioms">idiomatische uitdrukkingen</dfn>
+        </dt>
+        <dd>
+          <p>
+            uitdrukking waarvan de betekenis niet kan worden afgeleid uit de
+            betekenis van de afzonderlijke woorden en waarin de specifieke
+            woorden niet veranderd kunnen worden zonder dat de uitdrukking haar
+            betekenis verliest
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-96">
+
+            <div role="heading" class="note-title marker" id="h-note-96" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Idiomatische uitdrukkingen kunnen niet direct – woord voor woord –
+              worden vertaald zonder dat de uitdrukking haar (culturele of
+              taalgebonden) betekenis verliest.
+            </p>
+          </div>
+
+          <p class="example">
+            In het Engels betekent "spilling the beans" "een geheim onthullen."
+            Maar "knocking over the beans" of "spilling the vegetables"
+            betekenen niet hetzelfde.
+          </p>
+
+          <p class="example">
+            In het Japans kan de uitdrukking "<span lang="ja">さじを投げる</span>" letterlijk vertaald worden met "hij gooit de lepel," maar het
+            betekent dat hij niets meer kan doen en het uiteindelijk opgeeft.
+          </p>
+
+          <p class="example">
+            In het Nederlands kan "<span lang="nl">Hij ging met de kippen op stok</span>" letterlijk vertaald worden met ""He went to roost with the
+            chickens," maar het betekent dat hij vroeg naar bed ging.
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-informatief">informatief</dfn></dt>
+        <dd>
+          <p>ter informatie en niet vereist voor conformiteit</p>
+
+          <div class="note" role="note" id="issue-container-generatedID-97">
+
+            <div role="heading" class="note-title marker" id="h-note-97" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Content die voor
+              <a href="#dfn-conformiteitseisen" class="internalDFN" data-link-type="dfn">conformiteit</a>, is vereist wordt aangeduid met "<a href="#dfn-normatief" class="internalDFN" data-link-type="dfn">normatief</a>".
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-invoerfout">invoerfout</dfn></dt>
+        <dd>
+          <p>
+            door de gebruiker geleverde informatie die niet geaccepteerd wordt
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-98">
+
+            <div role="heading" class="note-title marker" id="h-note-98" aria-level="3">
+              <span>Noot</span>
+            </div>
+
+            <div class="">
+              <p>Dit omvat:</p>
+
+              <ol>
+                <li>
+                  informatie die de webpagina vereist, maar door de gebruiker
+                  wordt weggelaten;
+                </li>
+
+                <li>
+                  informatie die door de gebruiker wordt ingevoerd, maar buiten
+                  de vereiste gegevensindeling of waardenbereik valt.
+                </li>
+              </ol>
+            </div>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-jargon">jargon</dfn></dt>
+        <dd>
+          <p>
+            woorden die op een bijzondere manier door mensen in een bepaald
+            vakgebied worden gebruikt
+          </p>
+
+          <p class="example">
+            Het woord StickyKeys is jargon uit het vakgebied van de
+            hulptechnologie/toegankelijkheid.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="knipperende|knipperen" data-dfn-type="dfn" id="dfn-knipperende">knipperen</dfn>
+        </dt>
+        <dd>
+          <p>
+            het heen en weer schakelen tussen twee visuele toestanden op een
+            manier die bedoeld is om aandacht te trekken
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-99">
+
+            <div role="heading" class="note-title marker" id="h-note-99" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Zie ook
+              <a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">flits</a>. Het is mogelijk dat iets groot genoeg is en helder genoeg
+              knippert met de juiste frequentie om ook geclassificeerd te worden
+              als flits.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="labels|label" data-dfn-type="dfn" id="dfn-labels">label</dfn>
+        </dt>
+        <dd>
+          <p>
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            of andere component met een
+            <a href="#dfn-tekstalternatief" class="internalDFN" data-link-type="dfn">tekstalternatief</a>
+            die aan de gebruiker wordt gepresenteerd om een component binnen
+            <a href="#dfn-webcontent" class="internalDFN" data-link-type="dfn">webcontent</a>
+            te identificeren
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-100">
+
+            <div role="heading" class="note-title marker" id="h-note-100" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een label wordt aan alle gebruikers gepresenteerd, terwijl de
+              <a href="#dfn-naam" class="internalDFN" data-link-type="dfn">naam</a>
+              verborgen kan zijn en alleen wordt getoond door hulptechnologie.
+              In veel (maar niet alle) gevallen zijn de naam en het label
+              hetzelfde.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-101">
+
+            <div role="heading" class="note-title marker" id="h-note-101" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De term label is niet beperkt tot het label-element in HTML.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="basisonderwijs|lager middelbaar onderwijsniveau" data-dfn-type="dfn" id="dfn-basisonderwijs">lager middelbaar onderwijsniveau</dfn>
+        </dt>
+        <dd>
+          <p>
+            de opleidingsperiode van twee of drie jaar die begint na voltooiing
+            van zes jaar school en negen jaar na het begin van het
+            <a href="#dfn-basisonderwijs" class="internalDFN" data-link-type="dfn">basisonderwijs</a>
+            eindigt.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-102">
+
+            <div role="heading" class="note-title marker" id="h-note-102" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze definitie is gebaseerd op de
+              <span lang="en" xml:lang="en">International Standard Classification of Education van de
+                UNESCO</span>.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="purpose of each link|dubbelzinnige betekenis kan hebben voor gebruikers in het algemeen|linkdoel" data-dfn-type="dfn" id="dfn-purpose-of-each-link">linkdoel</dfn>
+        </dt>
+        <dd>
+          <p>
+            aard van het resultaat dat verkregen wordt door activering van een
+            hyperlink
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-live">live</dfn></dt>
+        <dd>
+          <p>
+            informatie die is opgenomen tijdens een reële gebeurtenis in de
+            samenleving en doorgestuurd naar de ontvanger met niet meer dan een
+            uitzendvertraging
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-103">
+
+            <div role="heading" class="note-title marker" id="h-note-103" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een uitzendvertraging is een korte (doorgaans geautomatiseerde)
+              vertraging, die bijvoorbeeld gebruikt wordt om de uitzender tijd
+              te geven om de audio- of video-invoer te serialiseren of te
+              censureren, maar niet voldoende om significante editing toe te
+              staan.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-104">
+
+            <div role="heading" class="note-title marker" id="h-note-104" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als informatie volledig wordt gegenereerd door een computer, is ze
+              niet direct.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-louter-geluid">louter-geluid</dfn>
+        </dt>
+        <dd>
+          <p>
+            een op tijd gebaseerde weergave die alleen
+            <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>
+            (geen
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>
+            en geen interactie) bevat
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-louter-videobeeld">louter-videobeeld</dfn>
+        </dt>
+        <dd>
+          <p>
+            een op tijd gebaseerde presentatie die alleen
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>
+            bevat (geen
+            <a href="#dfn-audio" class="internalDFN" data-link-type="dfn">audio</a>
+            en geen interactie)
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-mechanisme">mechanisme</dfn></dt>
+        <dd>
+          <p>
+            <a href="#dfn-processen" class="internalDFN" data-link-type="dfn">proces</a>
+            of techniek om een resultaat te bereiken
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-105">
+
+            <div role="heading" class="note-title marker" id="h-note-105" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Het mechanisme kan expliciet aangeboden worden in de content of er
+              kan
+              <a href="#dfn-gesteund-wordt" class="internalDFN" data-link-type="dfn">gesteund worden</a>
+              op levering door het platform of door
+              <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agents</a>, met inbegrip van
+              <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologieën</a>.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-106">
+
+            <div role="heading" class="note-title marker" id="h-note-106" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Het mechanisme moet voldoen aan alle succescriteria voor het
+              niveau in de conformiteitsclaim.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-media-alternatief-voor-tekst">media-alternatief voor tekst</dfn>
+        </dt>
+        <dd>
+          <p>
+            medium dat niet meer informatie presenteert dan al in de tekst wordt
+            gepresenteerd (direct of via tekstalternatieven)
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-107">
+
+            <div role="heading" class="note-title marker" id="h-note-107" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Er wordt een media-alternatief voor tekst aangeboden voor degenen
+              die baat hebben bij alternatieve representaties van tekst.
+              Mediumalternatieven voor tekst kunnen louter-geluid,
+              louter-videobeeld (waaronder gebarentaalvideo), of audio-video
+              zijn.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="human language(s)|menselijke taal" data-dfn-type="dfn" id="dfn-human-language-s">menselijke taal</dfn>
+        </dt>
+        <dd>
+          <p>
+            taal die wordt gesproken, geschreven of getekend (door visuele of
+            tastbare middelen) om met mensen te communiceren
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-108">
+
+            <div role="heading" class="note-title marker" id="h-note-108" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Zie ook
+              <a href="#dfn-gebarentaal" class="internalDFN" data-link-type="dfn">gebarentaal</a>.
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-naam">naam</dfn></dt>
+        <dd>
+          <p>
+            tekst waardoor software een component binnen webcontent kan
+            identificeren aan de gebruiker
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-109">
+
+            <div role="heading" class="note-title marker" id="h-note-109" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              De naam kan verborgen zijn en alleen door hulptechnologie vertoond
+              worden, terwijl een
+              <a href="#dfn-labels" class="internalDFN" data-link-type="dfn">label</a>
+              aan alle gebruikers wordt gepresenteerd. In veel (maar niet alle)
+              gevallen zijn de label en de naam hetzelfde.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-110">
+
+            <div role="heading" class="note-title marker" id="h-note-110" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">Dit staat los van het name-attribuut in HTML.</p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-niet-tekstuele-content">niet-tekstuele content</dfn>
+        </dt>
+        <dd>
+          <p>
+            alle content die niet een sequentie van karakters is die
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            kan worden of waar de sequentie niet iets in
+            <a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">menselijke taal</a>
+            uitdrukt
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-111">
+
+            <div role="heading" class="note-title marker" id="h-note-111" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Hierbij is inbegrepen
+              <a href="#dfn-ascii-art" class="internalDFN" data-link-type="dfn">ASCII-art</a>
+              (een patroon van tekens), emoticons, leet speak (dat gebruik maakt
+              van karaktersubstitutie) en afbeeldingen die tekst representeren.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-noodsituatie">noodsituatie</dfn>
+        </dt>
+        <dd>
+          <p>
+            een plotselinge, onverwachte situatie of gebeurtenis die
+            onmiddellijke actie vereist om gezondheid, veiligheid of eigendom te
+            behouden
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-normatief">normatief</dfn></dt>
+        <dd>
+          <p>voor conformiteit vereist</p>
+
+          <div class="note" role="note" id="issue-container-generatedID-112">
+
+            <div role="heading" class="note-title marker" id="h-note-112" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Men kan op verschillende specifieke manieren aan dit document
+              conformeren.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-113">
+
+            <div role="heading" class="note-title marker" id="h-note-113" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Content die geïdentificeerd is als "<a href="#dfn-informatief" class="internalDFN" data-link-type="dfn">informatief</a>" of "niet-normatief" is voor
+              <a href="#dfn-conformiteitseisen" class="internalDFN" data-link-type="dfn">conformiteit</a>
+              nooit vereist.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-ondertitels">ondertitels</dfn> (voor
+          doven en slechthorenden)
+        </dt>
+        <dd>
+          <p>
+            gesynchroniseerd visueel en/of
+            <a href="#dfn-tekstalternatief" class="internalDFN" data-link-type="dfn">tekstalternatief</a>
+            voor zowel gesproken als andersoortige audio-informatie, die bedoeld
+            is om de mediacontent te begrijpen
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-114">
+
+            <div role="heading" class="note-title marker" id="h-note-114" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Ondertitels voor doven en slechthorenden zijn vergelijkbaar met
+              ondertitels voor dialoog, behalve dat ondertitels voor doven en
+              slechthorenden niet alleen de inhoud van de gesproken dialoog
+              overbrengen, maar ook equivalenten voor andersoortige
+              audio-informatie die nodig is om de programma-inhoud te begrijpen,
+              met inbegrip van geluidseffecten, muziek, gelach, locatie en
+              identificatie van de spreker.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-115">
+
+            <div role="heading" class="note-title marker" id="h-note-115" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Gesloten ondertitels voor doven en slechthorenden zijn
+              equivalenten die bij sommige spelers aan- en uitgezet kunnen
+              worden.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-116">
+
+            <div role="heading" class="note-title marker" id="h-note-116" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Open ondertitels voor doven en slechthorenden zijn alle
+              ondertitels voor doven en slechthorenden die niet uitgezet kunnen
+              worden. Bijvoorbeeld, als ondertitels voor doven en slechthorenden
+              visueel equivalente
+              <a href="#dfn-afbeeldingen-van-tekst-zijn" class="internalDFN" data-link-type="dfn">afbeeldingen van tekst zijn</a>, ingebed in
+              <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-117">
+
+            <div role="heading" class="note-title marker" id="h-note-117" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Ondertitels voor doven en slechthorenden horen relevante
+              informatie in de video niet onduidelijk te maken of in de weg te
+              staan.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-118">
+
+            <div role="heading" class="note-title marker" id="h-note-118" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              In sommige landen worden ondertitels voor doven en slechthorenden
+              ondertitels genoemd.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-119">
+
+            <div role="heading" class="note-title marker" id="h-note-119" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              <a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">Audiodescripties</a>
+              kunnen ondertitels voor doven en slechthorenden krijgen, maar dat
+              hoeft niet, aangezien het beschrijvingen zijn van informatie die
+              visueel al gepresenteerd wordt.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-op-een-ongebruikelijke-of-beperkte-manier-gebruikt">op een ongebruikelijke of beperkte manier gebruikt</dfn>
+        </dt>
+        <dd>
+          <p>
+            woorden die gebruikt worden op een speciale manier die van
+            gebruikers vereist dat ze precies weten welke definitie ze moeten
+            toepassen om de content correct te begrijpen
+          </p>
+
+          <p class="example">
+            De term "gig" betekent iets anders als ze voorkomt in een discussie
+            over muziekconcerten dan als ze voorkomt in een artikel over
+            computer harde schijf ruimte, maar de juiste definitie kan bepaald
+            worden uit de context. Daarentegen wordt het woord "tekst" op een
+            heel specifieke manier gebruikt in WCAG 2.0, dus een definitie wordt
+            gegeven in de verklarende woordenlijst.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-op-een-venster-even-groot-als-het-volle-beeld">op een venster even groot als het volle beeld</dfn>
+        </dt>
+        <dd>
+          <p>
+            op een desktop/laptop scherm van de meest gangbare grootte met
+            gemaximaliseerd weergavekader
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-120">
+
+            <div role="heading" class="note-title marker" id="h-note-120" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Aangezien mensen hun computers in het algemeen verscheidene jaren
+              houden, is het het beste om, als deze evaluatie wordt gemaakt,
+              niet af te gaan op de meest recente
+              desktop/laptop-schermresoluties, maar de gangbare
+              desktop/laptop-schermresoluties gemiddeld over diverse jaren in
+              acht te nemen.
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-paragraaf">paragraaf</dfn></dt>
+        <dd>
+          <p>
+            Een op zichzelf staand gedeelte van geschreven content die gaat over
+            één of meer gerelateerde onderwerpen of ideeën
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-121">
+
+            <div role="heading" class="note-title marker" id="h-note-121" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een paragraaf kan bestaan uit één of meer alinea's en grafieken,
+              tabellen, lijsten en subparagrafen bevatten.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-lt="pause|pauzeren" data-dfn-type="dfn" id="dfn-pause">pauzeren</dfn>
+        </dt>
+        <dd>
+          <p>
+            gestopt op verzoek van gebruiker en niet eerder hervat dan op
+            verzoek van gebruiker
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-presentatie">presentatie</dfn></dt>
+        <dd>
+          <p>
+            weergave van de
+            <a href="#dfn-webcontent" class="internalDFN" data-link-type="dfn">content</a>
+            in een door gebruikers waar te nemen vorm
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="processen|proces" data-dfn-type="dfn" id="dfn-processen">proces</dfn>
+        </dt>
+        <dd>
+          <p>
+            serie handelingen van de gebruiker waarbij elke handeling vereist is
+            om een activiteit te voltooien
+          </p>
+
+          <p class="example">
+            Succesvol gebruik van een serie webpagina's op een winkelwebsite
+            vereist dat gebruikers alternatieve producten, prijzen en
+            aanbiedingen bekijken, producten kiezen, een bestelling invoeren en
+            verzenden, verzendinformatie en betaalinformatie geven.
+          </p>
+
+          <p class="example">
+            Een pagina voor registratie van een account vereist succesvolle
+            voltooiing van een Turingtest voordat aan het registratieformulier
+            toegang wordt gegeven.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-puur-decoratief">puur decoratief</dfn>
+        </dt>
+        <dd>
+          <p>
+            dient alleen een esthetisch doel, geeft geen informatie en heeft
+            geen functionaliteit
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-122">
+
+            <div role="heading" class="note-title marker" id="h-note-122" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Tekst is alleen puur decoratief als de woorden gerangschikt of
+              vervangen kunnen worden zonder dat hun doel verandert.
+            </p>
+          </div>
+
+          <p class="example">
+            De omslagpagina van een woordenboek heeft willekeurig uitgezochte
+            woorden in zeer lichte tekst op de achtergrond.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="livegebeurtenis|real-time gebeurtenissen" data-dfn-type="dfn" id="dfn-livegebeurtenis">real-time gebeurtenissen</dfn>
+          (realtime-event)
+        </dt>
+        <dd>
+          <p>
+            gebeurtenis die a) plaatsvindt op dezelfde tijd als het kijken en b)
+            niet volledig gegenereerd wordt door de content
+          </p>
+
+          <p class="example">
+            Een webcast van een live-uitvoering (vindt plaats op dezelfde tijd
+            als het kijken en is niet vooraf opgenomen).
+          </p>
+
+          <p class="example">
+            Een online veiling met biedende mensen (vindt plaats op dezelfde
+            tijd als het kijken).
+          </p>
+
+          <p class="example">
+            Levende mensen die door middel van avatars in een virtuele wereld
+            interacteren (wordt niet volledig gegenereerd door de content en
+            vindt plaats op dezelfde tijd als het kijken).
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="regions|regio's|region" data-dfn-type="dfn" id="dfn-regions">region</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            waarneembaar,
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            gedeelte van content
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-123">
+
+            <div role="heading" class="note-title marker" id="h-note-123" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              In HTML is elk gebied met een landmark role een region.
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-relaties">relaties</dfn></dt>
+        <dd>
+          <p>betekenisvolle verbanden tussen verschillende stukken content</p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-relatieve-luminantie">relatieve luminantie</dfn>
+        </dt>
+        <dd>
+          <p>
+            de relatieve helderheid van elk punt in een kleurenruimte,
+            genormaliseerd naar 0 voor het donkerste zwart en 1 voor het
+            lichtste wit
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-124">
+
+            <div role="heading" class="note-title marker" id="h-note-124" aria-level="3">
+              <span>Noot</span>
+            </div>
+
+            <div class="">
+              <p>
+                Voor de sRGB-kleurenruimte is de relatieve luminantie van een
+                kleur gedefinieerd als L = 0,2126 * <strong>R</strong> + 0.7152
+                * <strong>G</strong> + 0.0722 * <strong>B</strong> waar
+                <strong>R</strong>, <strong>G</strong> en
+                <strong>B</strong> gedefinieerd zijn als:
+              </p>
+
+              <ul>
+                <li>
+                  als RsRGB &lt;= 0.03928 dan <strong>R</strong> = RsRGB/12.92
+                  anders <strong>R</strong> = ((RsRGB+0.055)/1.055) ^ 2.4
+                </li>
+
+                <li>
+                  als GsRGB &lt;= 0.03928 dan <strong>G</strong> = GsRGB/12.92
+                  anders <strong>G</strong> = ((GsRGB+0.055)/1.055) ^ 2.4
+                </li>
+
+                <li>
+                  als BsRGB &lt;= 0.03928 dan <strong>B</strong> = BsRGB/12.92
+                  anders <strong>B</strong> = ((BsRGB+0.055)/1.055) ^ 2.4
+                </li>
+              </ul>
+
+              <p>en RsRGB, GsRGB en BsRGB gedefinieerd zijn als:</p>
+
+              <ul>
+                <li>RsRGB = R8bit/255</li>
+
+                <li>GsRGB = G8bit/255</li>
+
+                <li>BsRGB = B8bit/255</li>
+              </ul>
+
+              <p>
+                Het "^"-symbool is de machtsverheffingsoperator. (Formule
+                overgenomen uit [<cite><a class="bibref" href="#bib-srgb" title="A Standard Default Color Space for the Internet - sRGB, Version 1.10" data-link-type="biblio">sRGB</a></cite>] en [<cite><a class="bibref" href="#bib-iec-4wd" title="IEC/4WD 61966-2-1: Colour Measurement and Management in Multimedia Systems and Equipment - Part 2.1: Default Colour Space - sRGB" data-link-type="biblio">IEC-4WD</a></cite>]).
+              </p>
+            </div>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-137"><div role="heading" class="note-title marker" id="h-note-137" aria-level="3"><span>Note 2</span></div><p class="">Voor mei 2021 was de waarde 0,04045 in de definitie anders (0,03928). Het werd eerder overgenomen uit een oudere versie van de specificatie en is nu bijgewerkt. Dit heeft geen praktisch effect op de berekeningen in de context van deze richtlijnen. </p></div>
+
+
+          <div class="note" role="note" id="issue-container-generatedID-125">
+
+            <div role="heading" class="note-title marker" id="h-note-125" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Bijna alle systemen die tegenwoordig gebruikt worden om webcontent
+              te bekijken werken met sRGB-codering. Tenzij bekend is dat een
+              andere kleurenruimte gebruikt zal worden om de content te
+              verwerken en te vertonen, moeten auteurs de sRGB-kleurenruimte
+              gebruiken om kleuren te evalueren. Indien andere kleurenruimtes
+              gebruikt worden, zie Contrast (Minimum):
+              <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast">Understanding Success Criterion 1.4.3</a>.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-126">
+
+            <div role="heading" class="note-title marker" id="h-note-126" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Als dithering plaatsvindt na aflevering, wordt de bronkleurwaarde
+              gebruikt. Voor kleuren die geditherd worden bij de bron, moeten de
+              gemiddelde waarden van de kleuren die geditherd worden gebruikt
+              worden (gemiddelde R, gemiddelde G en gemiddelde B).
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-127">
+
+            <div role="heading" class="note-title marker" id="h-note-127" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Er zijn instrumenten beschikbaar die de berekeningen om contrast
+              en flits te testen automatisch doen.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-128">
+
+            <div role="heading" class="note-title marker" id="h-note-128" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Er is een
+              <a href="relative-luminance.xml">MathML-versie van de relatieve helderheidsdefinitie</a>
+              beschikbaar.
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-rol">rol</dfn></dt>
+        <dd>
+          <p>
+            tekst of getal waardoor software de functie van een component binnen
+            webcontent kan identificeren
+          </p>
+
+          <p class="example">
+            Een getal dat aangeeft of een afbeelding dienst doet als hyperlink,
+            commandoknop of aanvinkhokje.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-sequentieel-genavigeerd">sequentieel genavigeerd</dfn>
+        </dt>
+        <dd>
+          <p>
+            genavigeerd in de volgorde gedefinieerd voor het voortbewegen van de
+            focus (van één element naar het volgende) door middel van een
+            <a href="#dfn-toetsenbordinterface" class="internalDFN" data-link-type="dfn">toetsenbordinterface</a>
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="keyboard shortcuts|sneltoets" data-dfn-type="dfn" id="dfn-keyboard-shortcuts">sneltoets</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            alternatieve manier om een actie te activeren door op één of
+            meerdere toetsen te drukken
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-specifieke-zintuiglijke-ervaring">specifieke zintuiglijke ervaring</dfn>
+        </dt>
+        <dd>
+          <p>
+            een zintuiglijke ervaring die niet puur decoratief is en niet
+            primair belangrijke informatie overbrengt of een functie uitvoert
+          </p>
+
+          <p class="example">
+            Een uitvoering van een fluitsolo, visuele kunst, enz.
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="statussen|status (toestand)" data-dfn-type="dfn" id="dfn-statussen">status (toestand)</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            dynamische eigenschap die de kenmerken weergeeft van een component
+            van de gebruikersinterface die mogelijk verandert als gevolg van een
+            actie van de gebruiker of van geautomatiseerde processen
+          </p>
+
+          <p>
+            De toestand heeft geen invloed op de aard van de component. De
+            toestand vertegenwoordigt de gegevens met betrekking tot de
+            component of de mogelijke gebruikersinteracties. Voorbeelden:
+            gefocust, zwevend (hover), geselecteerd, ingedrukt, gecontroleerd,
+            bezocht/niet bezocht en uit-/samengevouwen.
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="statusberichten|statusbericht" data-dfn-type="dfn" id="dfn-statusberichten">statusbericht</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            een bericht dat een verandering van content maar geen
+            <a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">contextwijziging</a>
+            is en dat informatie geeft aan de gebruiker over het succes of de
+            resultaten van een actie, over de wachtstatus van een applicatie,
+            over de voortgang van een proces of over eventuele fouten
+          </p>
+        </dd>
+
+        <dt class="new">
+          <dfn data-lt="stijleigenschappen|stijleigenschap" data-dfn-type="dfn" id="dfn-stijleigenschappen">stijleigenschap</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            eigenschap waarvan de waarde bepaalt hoe content elementen worden
+            weergegeven (lettertype, kleur, grootte locatie, opvulling volume,
+            gesynthetiseerde zinsmelodie) wanneer ze door user agents worden
+            weergegeven (bijv. op het scherm, via de luidspreker, via een
+            braillebeeldscherm)
+          </p>
+          <p>Stijleigenschappen hebben verschillende oorsprongen:</p>
+          <ul>
+            <li>
+              Standaardstijl van user agent: De waarden van de eigenschappen van
+              de standaardstijl worden toegepast wanneer er geen stijlen van
+              auteurs of andere gebruikers aanwezig zijn. Sommige webcontent
+              technologieën specificeren een standaardweergave, andere
+              technologieën doen dit niet;
+            </li>
+            <li>
+              Stijlen van de auteur: De waarden van de eigenschappen van de
+              stijl worden ingesteld door de auteur als onderdeel van de content
+              (bijv. in-line-stijlen, style sheet van de auteur);
+            </li>
+            <li>
+              Stijlen van de gebruiker: De waarden van de eigenschappen van de
+              stijl worden ingesteld door de gebruiker (bijv. via de
+              interface-instellingen van de user agent, style sheet van de
+              gebruiker)
+            </li>
+          </ul>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-structuur">structuur</dfn></dt>
+        <dd>
+          <ol>
+            <li>
+              De wijze waarop onderdelen van
+              <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+              zijn gestructureerd ten opzichte van elkaar, en
+            </li>
+
+            <li>
+              De wijze waarop een verzameling
+              <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+              is georganiseerd
+            </li>
+          </ol>
+        </dd>
+
+        <dt>
+          <dfn data-lt="technologies|technologieën|webtechnologie|webcontenttechnologieën|webcontenttechnologie|webcontent technologieën|webcontent technologie|technologie" data-dfn-type="dfn" id="dfn-technologies">technologie</dfn>
+          (webcontent)
+        </dt>
+        <dd>
+          <p>
+            <a href="#dfn-mechanisme" class="internalDFN" data-link-type="dfn">mechanisme</a>
+            om instructies te coderen die weergegeven, afgespeeld of uitgevoerd
+            worden door
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agents</a>
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-129">
+
+            <div role="heading" class="note-title marker" id="h-note-129" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Zoals ze in deze richtlijnen gebruikt worden, verwijzen
+              "webtechnologie" en het woord "technologie" (als het afzonderlijk
+              wordt gebruikt) beide naar webcontent technologieën.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-130">
+
+            <div role="heading" class="note-title marker" id="h-note-130" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Onder webcontent technologieën kunnen vallen: opmaaktalen,
+              gegevensformaten of programmeertalen die auteurs alleen kunnen
+              gebruiken of in combinatie om eindgebruikers-ervaringen te creëren
+              die variëren van statische webpagina's tot gesynchroniseerde
+              mediapresentaties tot dynamische webapplicaties.
+            </p>
+          </div>
+
+          <p class="example">
+            Enige gangbare voorbeelden van webcontent technologieën zijn HTML,
+            CSS, SVG, PNG, PDF, Flash en JavaScript.
+          </p>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-tekst">tekst</dfn></dt>
+        <dd>
+          <p>
+            sequentie van karakters die
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            kan worden, waar de sequentie iets in
+            <a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">menselijke taal</a>
+            uitdrukt
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-tekstalternatief">tekstalternatief</dfn>
+        </dt>
+        <dd>
+          <p>
+            <a href="#dfn-tekst" class="internalDFN" data-link-type="dfn">tekst</a>
+            die door software is geassocieerd met
+            <a href="#dfn-niet-tekstuele-content" class="internalDFN" data-link-type="dfn">niet-tekstuele content</a>
+            of waarnaar verwezen wordt vanuit tekst die door software is
+            geassocieerd met niet-tekstuele content. Door software geassocieerde
+            tekst is tekst waarvan de locatie
+            <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">door software bepaald</a>
+            kan worden uit de niet-tekstuele content
+          </p>
+
+          <p class="example">
+            Een afbeelding van een grafiek wordt in tekst beschreven in de
+            alinea na de grafiek. Het korte tekstalternatief voor de grafiek
+            geeft aan dat een beschrijving volgt.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-131">
+
+            <div role="heading" class="note-title marker" id="h-note-131" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Zie
+              <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding "Text Alternatives"</a>
+              voor meer informatie.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-tekstblokken">tekstblokken</dfn>
+        </dt>
+        <dd>
+          <p>
+            meer dan één zin tekst
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-toetsenbordinterface">toetsenbordinterface</dfn>
+        </dt>
+        <dd>
+          <p>
+            interface die gebruikt wordt door software om invoer van een
+            toetsaanslag te verkrijgen
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-132">
+
+            <div role="heading" class="note-title marker" id="h-note-132" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Een toetsenbordinterface staat gebruikers toe om invoer door
+              middel van toetsaanslagen te leveren aan programma's, zelfs als de
+              technologie oorspronkelijk geen toetsenbord bevat.
+            </p>
+          </div>
+
+          <p class="example">
+            Een PDA met aanraakscherm heeft zowel een toetsenbordinterface in
+            zijn besturingssysteem ingebouwd als een aansluitpunt voor externe
+            toetsenborden. Applicaties op de PDA kunnen de interface gebruiken
+            om toetsenbordinvoer te verkrijgen ofwel van een extern toetsenbord
+            of van andere applicaties die gesimuleerde toetsenborduitvoer
+            leveren, zoals handschriftvertolkers of spraak-naar-tekst
+            applicaties met "toetsenbord-emulatie functionaliteit".
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-133">
+
+            <div role="heading" class="note-title marker" id="h-note-133" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Bediening van de applicatie (of onderdelen van de applicatie) door
+              middel van een door een toetsenbord bediende muisemulator, zoals
+              muistoetsen, wordt niet beschouwd als bediening door middel van
+              een toetsenbordinterface, omdat de bediening van het programma
+              gebeurt door middel van zijn aanwijsinterface, niet door middel
+              van zijn toetsenbordinterface.
+            </p>
+          </div>
+        </dd>
+
+        <dt class="new">
+          <dfn data-dfn-type="dfn" id="dfn-up-event">up-event</dfn>
+        </dt>
+        <dd class="new">
+          <p>
+            gebeurtenis die plaatsvindt binnen een platform wanneer de trigger
+            van de aanwijzer wordt losgelaten
+          </p>
+          <p>
+            De up-event heeft binnen andere platformen mogelijk een andere naam,
+            zoals "touchend" of "mouseup".
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="user agents|user agent" data-dfn-type="dfn" id="dfn-user-agents">user agent</dfn>
+        </dt>
+        <dd>
+          <p>
+            alle software die webcontent voor gebruikers ophaalt en presenteert
+          </p>
+
+          <p class="example">
+            Webbrowsers, mediaspelers, plug-ins en andere programma's –
+            waaronder
+            <a href="#dfn-hulptechnologieen" class="internalDFN" data-link-type="dfn">hulptechnologieën</a>
+            – die helpen bij het ophalen en weergeven van en het interacteren
+            met webcontent.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-verlengde-audiodescriptie">verlengde audiodescriptie</dfn>
+        </dt>
+        <dd>
+          <p>
+            audiodescriptie die wordt toegevoegd aan een audiovisuele
+            presentatie door de
+            <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>
+            te pauzeren zodat er tijd is om een aanvullende beschrijving toe te
+            voegen
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-134">
+
+            <div role="heading" class="note-title marker" id="h-note-134" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze techniek wordt alleen gebruikt als de sfeer van de
+              <a href="#dfn-video" class="internalDFN" data-link-type="dfn">video</a>
+              zonder de aanvullende
+              <a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">audiodescriptie</a>
+              verloren zou gaan en de pauzes tussen dialoog/gesproken tekst te
+              kort zijn.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-verzameling-webpagina-s">verzameling webpagina's</dfn>
+        </dt>
+        <dd>
+          <p>
+            een verzameling
+            <a href="#dfn-webpagina" class="internalDFN" data-link-type="dfn">webpagina's</a>
+            die een gemeenschappelijk doel delen en die worden gecreëerd door
+            dezelfde auteur, groep of organisatie
+          </p>
+
+          <aside class="example" id="example-28"><div class="marker">Voorbeeld</div><p>Voorbeelden zijn onder andere:</p>
+            <ul>
+            <li>een publicatie die over verschillende webpagina's is verdeeld en waarbij elke pagina één hoofdstuk of een ander afgebakend gedeelte van het werk bevat. De publicatie is logischerwijs een enkele, doorlopende eenheid die navigatiefuncties bevat die toegang bieden tot de volledige verzameling  pagina's.</li>
+            <li>een e-commercewebsite die producten toont op een verzameling webpagina's die allemaal dezelfde navigatie en identificatie delen. Echter, bij het doorgaan naar het uitchecken verandert de template; de navigatie en andere elementen worden verwijderd, zodat de pagina's in dat proces functioneel en visueel anders zijn. De uitcheckpagina’s maken geen deel uit van de set productpagina's.</li>
+            <li>een blog op een subdomein (bijvoorbeeld blog.example.com) die een andere navigatie heeft en wordt geschreven door een aparte groep mensen ten opzichte van de pagina's op het hoofddomein (example.com).</li>
+         </ul></aside>
+
+          <div class="note" role="note" id="issue-container-generatedID-135">
+
+            <div role="heading" class="note-title marker" id="h-note-135" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Verschillende taalversies worden beschouwd als verschillende
+              verzamelingen webpagina's.
+            </p>
+          </div>
+        </dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-video">video</dfn></dt>
+        <dd>
+          <p>
+            de technologie van bewegende of opeenvolgende plaatjes of
+            afbeeldingen
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-136">
+
+            <div role="heading" class="note-title marker" id="h-note-136" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Video kan gemaakt worden van animatiebeelden of fotografische
+              beelden of beide.
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-visueel-aangepast">visueel aangepast</dfn>
+        </dt>
+        <dd>
+          <p>
+            lettertype, grootte, kleur en achtergrond kunnen ingesteld worden
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="voldoet|voldoet aan een succescriterium" data-dfn-type="dfn" id="dfn-voldoet">voldoet aan een succescriterium</dfn>
+        </dt>
+        <dd>
+          <p>
+            het succescriterium evalueert niet tot 'fout' als het op de pagina
+            wordt toegepast vooraf opgenomen
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-vooraf-opgenomen">vooraf opgenomen</dfn>
+        </dt>
+        <dd>
+          <p>
+            informatie die niet
+            <a href="#dfn-live" class="internalDFN" data-link-type="dfn">live</a>
+            is
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-lt="webpagina|webpagina(s)|webpagina's" data-dfn-type="dfn" id="dfn-webpagina">webpagina's</dfn>
+        </dt>
+        <dd>
+          <p>
+            een niet ingebed bestand dat door middel van HTTP verkregen wordt
+            uit een enkele URI plus alle andere bestanden die door een
+            <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agent</a>
+            gebruikt worden bij het weergeven of bedoeld zijn om samen met het
+            niet ingebedde bestand te worden weergegeven
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-137">
+
+            <div role="heading" class="note-title marker" id="h-note-137" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Hoewel alle "andere bestanden" weergegeven zouden worden met het
+              primaire bestand, zouden ze niet noodzakelijk tegelijkertijd met
+              elkaar worden.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-138">
+
+            <div role="heading" class="note-title marker" id="h-note-138" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Ter wille van conformiteit met deze richtlijnen moet een bestand
+              "niet ingebed" zijn binnen de reikwijdte van conformiteit om als
+              een webpagina te worden.
+            </p>
+          </div>
+
+          <p class="example">
+            Een webbestand met inbegrip van alle ingebedde afbeeldingen en
+            media.
+          </p>
+
+          <p class="example">
+            Een webmailprogramma dat opgebouwd is met gebruik van Asynchrone
+            JavaScript en XML (AJAX). Het programma bevindt zich in zijn geheel
+            op http://example.com/mail, maar bevat een inbox, een lijst met
+            contacten en een kalender. Er worden links of knoppen geleverd, die
+            er voor zorgen dat de inbox, de lijst met contacten of de kalender
+            getoond worden, maar die de URI van de pagina als geheel niet
+            veranderen.
+          </p>
+
+          <p class="example">
+            Een aanpasbare portaalpagina waarbij gebruikers te tonen content
+            kunnen kiezen uit een set van verschillende contentmodules.
+          </p>
+
+          <p class="example">
+            Als je met je browser naar "http://shopping.example.com/" gaat, ga
+            je een filmachtige interactieve winkel binnen waar je je visueel in
+            een winkel verplaatst en producten van de schappen om je heen pakt
+            en in een visuele winkelwagen voor je plaatst. Als je een product
+            aanklikt, wordt het aan je gedemonstreerd met een folder met
+            specificaties daarnaast zwevend. Dit kan een website van een enkele
+            pagina zijn of gewoon één pagina binnen een website.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-weergavekader">weergavekader</dfn>
+        </dt>
+        <dd>
+          <p>object waarin de user agent content presenteert</p>
+
+          <div class="note" role="note" id="issue-container-generatedID-139">
+
+            <div role="heading" class="note-title marker" id="h-note-139" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              de
+              <a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">user agent</a>
+              presenteert content door één of meer weergavekaders.
+              Weergavekaders omvatten beeldschermvensters, frames, luidsprekers
+              en virtuele vergrootglazen. Een weergavekader kan zelf een
+              weergavekader bevatten (geneste frames bijvoorbeeld). Door de user
+              agent gecreëerde interface componenten, zoals
+              signaleringscomponenten, menu's en alert meldingen, zijn geen
+              weergavekaders.
+            </p>
+          </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-140">
+
+            <div role="heading" class="note-title marker" id="h-note-140" aria-level="3">
+              <span>Noot</span>
+            </div>
+            <p class="">
+              Deze definitie is gebaseerd op
+              <a href="https://www.w3.org/TR/WAI-USERAGENT/glossary.html">User Agent Accessibility Guidelines 1.0 Glossary</a>[<cite><a class="bibref" href="#bib-uaag10" title="User Agent Accessibility Guidelines 1.0" data-link-type="biblio">UAAG10</a></cite>].
+            </p>
+          </div>
+        </dd>
+
+        <dt>
+          <dfn data-dfn-type="dfn" id="dfn-wettelijke-verplichtingen">wettelijke verplichtingen</dfn>
+        </dt>
+        <dd>
+          <p>
+            transacties waarbij de persoon een overeenkomst aangaat waaruit
+            juridisch bindende rechten en plichten voortkomen
+          </p>
+
+          <p class="example">
+            Een huwelijksakte, handel in aandelen (financieel en juridisch), een
+            testament, een lening, adoptie, voor het leger tekenen, elk
+            willekeurig contract, etc.
+          </p>
+        </dd>
+      </dl>
+    </section>
+
+    <section id="input-purposes">
+      <h2 id="x7-inputdoelen-voor-componenten-van-de-gebruikersinterface">
+        <bdi class="secno">7. </bdi>Inputdoelen voor componenten van de
+        gebruikersinterface<a class="self-link" aria-label="§" href="#input-purposes"></a>
+      </h2>
+      <p>
+        Deze paragraaf omvat een lijst van de meest gebruikte inputdoelen van
+        <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">componenten van de gebruikersinterface</a>. De onderstaande termen zijn niet de trefwoorden die moeten worden
+        gebruikt. De termen beschrijven de doelen die moeten worden gevangen in
+        de taxonomie van een webpagina. Indien van toepassing kunnen auteurs de
+        bedieningselementen opmaken met de gekozen taxonomie om het semantisch
+        doel aan te geven. Dit biedt de mogelijkheid aan user agents en
+        hulptechnologieën om gepersonaliseerde weergaven toe te passen, waardoor
+        meer mensen de content kunnen begrijpen en gebruiken.
+      </p>
+
+      <div class="note" role="note" id="issue-container-generatedID-141">
+
+        <div role="heading" class="note-title marker" id="h-note-141" aria-level="3">
+          <span>Noot</span>
+        </div>
+        <p class="">
+          De lijst met typen inputdoelen is opgesteld op basis van de
+          bedieningsdoelen die zijn gedefinieerd in
+          <a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 Autofill field paragraaf</a>. Het is belangrijk om te begrijpen dat een andere technologie
+          mogelijk een aantal dezelfde of precies dezelfde concepten hanteert
+          die zijn gedefinieerd in de specificatie en dat alleen de concepten
+          behorende bij de betekenissen hieronder vereist zijn.
+        </p>
+      </div>
+
+      <p>
+        De volgende inputdoelen zijn gerelateerd aan de gebruiker van de content
+        en hebben alleen betrekking op de informatie van de betreffende
+        gebruiker.
+      </p>
+
+      <ul>
+        <li><strong>name</strong> - Volledige naam</li>
+        <li>
+          <strong>honorific-prefix</strong> - Voorvoegsel of titel (bijv.
+          "Dhr.", "Mevr.", "Dr.", "M<sup>lle</sup>")
+        </li>
+
+        <li><strong>given-name</strong> - <em>Voornaam</em></li>
+        <li>
+          <strong>additional-name</strong> - Andere voornamen (in sommige
+          westerse culturen worden deze ook wel <em>doopnamen</em> genoemd,
+          andere namen dan de voornaam)
+        </li>
+
+        <li>
+          <strong>family-name</strong> - Familienaam (in sommige westerse
+          culturen wordt deze ook wel <em>achternaam</em> genoemd)
+        </li>
+
+        <li>
+          <strong>honorific-suffix</strong> - Achtervoegsel (bijv., "Jr.",
+          "B.Sc.", "MBASW", "II")
+        </li>
+        <li>
+          <strong>nickname</strong> - Bijnaam, schermnaam, handle: een veelal
+          korte naam die wordt gebruikt in plaats van de volledige naam
+        </li>
+        <li>
+          <strong>organization-title</strong> - Functietitel (bijv., "Software
+          Engineer", "Senior Vice President", "Deputy Managing Director")
+        </li>
+        <li><strong>username</strong> - Een gebruikersnaam</li>
+        <li>
+          <strong>new-password</strong> - Een nieuw wachtwoord (bijv. bij het
+          aanmaken van een account of het wijzigen van een wachtwoord)
+        </li>
+        <li>
+          <strong>current-password</strong> - Het huidige wachtwoord voor het
+          account die wordt geïdentificeerd door het veld
+          <strong>username</strong> (bijv. bij het inloggen)
+        </li>
+
+        <li>
+          <strong>organization</strong> - Bedrijfsnaam die hoort bij de persoon,
+          het adres of de contactgegevens in de andere velden die gerelateerd
+          zijn aan dit veld
+        </li>
+        <li>
+          <strong>street-address</strong> - Adres (meerdere regels, nieuwe
+          regels behouden)
+        </li>
+        <li>
+          <strong>address-line1</strong> - Adres (één regel per veld, regel 1)
+        </li>
+        <li>
+          <strong>address-line2</strong> - Adres (één regel per veld, regel 2)
+        </li>
+        <li>
+          <strong>address-line3</strong> - Adres (één regel per veld, regel 3)
+        </li>
+        <li>
+          <strong>address-level4</strong> - Het meest gedetailleerde
+          administratieve niveau, bij adressen met vier administratieve niveaus
+        </li>
+        <li>
+          <strong>address-level3</strong> - Het derde administratieve niveau,
+          bij adressen met drie of meer administratieve niveaus
+        </li>
+        <li>
+          <strong>address-level2</strong> - Het tweede administratieve niveau,
+          bij adressen met twee of meer administratieve niveaus; in landen met
+          twee administratieve niveaus is dit gewoonlijk de gemeente, de stad,
+          het dorp of de plaats waar het betreffende adres zich bevindt.
+        </li>
+        <li>
+          <strong>address-level1</strong> - Het minst gedetailleerde
+          administratieve niveau, ofwel de provincie waar de plaats zich
+          bevindt; in de Verenigde Staten is dit bijvoorbeeld de staat, in
+          Zwitserland het kanton en in het Verenigd Koninkrijk de 'post town'
+        </li>
+        <li><strong>country</strong> - Landcode</li>
+        <li><strong>country-name</strong> - Naam van het land</li>
+        <li>
+          <strong>postal-code</strong> - Postal code, postcode, ZIP code,
+          CEDEX-code (bij CEDEX, voeg "CEDEX" en het
+          <span lang="fr" xml:lang="fr"><em>dissement</em></span> toe, indien
+          relevant, aan het veld <strong>address-level2</strong>)
+        </li>
+
+        <li><strong>cc-name</strong> - Volledige naam op het betaalmiddel</li>
+        <li>
+          <strong>cc-given-name</strong> - <em>Voornaam</em> op het betaalmiddel
+        </li>
+        <li>
+          <strong>cc-additional-name</strong> - Andere voornamen op het
+          betaalmiddel (in sommige westerse culturen worden deze ook wel
+          <em>doopnamen</em> genoemd, andere namen dan de voornaam)
+        </li>
+        <li>
+          <strong>cc-family-name</strong> - Familienaam op het betaalmiddel (in
+          sommige westerse culturen wordt deze ook wel
+          <em>achternaam</em> genoemd)
+        </li>
+
+        <li>
+          <strong>cc-number</strong> - Identificatiecode op het betaalmiddel
+          (bijv. het creditcardnummer)
+        </li>
+        <li><strong>cc-exp</strong> - Vervaldatum van het betaalmiddel</li>
+        <li>
+          <strong>cc-exp-month</strong> - Maand van de vervaldatum van het
+          betaalmiddel
+        </li>
+        <li>
+          <strong>cc-exp-year</strong> - Jaar van de vervaldatum van het
+          betaalmiddel
+        </li>
+        <li>
+          <strong>cc-csc</strong> - Beveiligingscode van het betaalmiddel (ook
+          wel Card Security Code (CSC), Card Validation Code (CVC), Card
+          Verification Value (CVV), Signature Panel Code (SPC), Credit Card ID
+          (CCID) genoemd)
+        </li>
+        <li><strong>cc-type</strong> - Type betaalmiddel</li>
+
+        <li>
+          <strong>transaction-currency</strong> - De valuta waarin de gebruiker
+          de transactie wil uitvoeren
+        </li>
+        <li>
+          <strong>transaction-amount</strong> - De hoeveelheid die de gebruiker
+          voor de transactie wil uitgeven (bijv. bij het invoeren van een bod of
+          verkoopprijs)
+        </li>
+
+        <li><strong>language</strong> - Voorkeurstaal</li>
+        <li><strong>bday</strong> - Geboortedatum</li>
+        <li><strong>bday-day</strong> - Geboortedag</li>
+        <li><strong>bday-month</strong> - Geboortemaand</li>
+        <li><strong>bday-year</strong> - Geboortejaar</li>
+
+        <li><strong>sex</strong> - Geslacht (bijv., Vrouwelijk, Fa’afafine)</li>
+        <li>
+          <strong>url</strong> - Startpagina of andere webpagina die hoort bij
+          het bedrijf, de persoon, het adres of de contactgegevens in de andere
+          velden die gerelateerd zijn aan dit veld
+        </li>
+        <li>
+          <strong>photo</strong> - Foto, pictogram of andere afbeelding die
+          hoort bij het bedrijf, de persoon, het adres of de contactgegevens in
+          de andere velden die gerelateerd zijn aan dit veld
+        </li>
+
+        <li>
+          <strong>tel</strong> - Volledig telefoonnummer, inclusief landcode
+        </li>
+        <li>
+          <strong>tel-country-code</strong> - Landcode van het telefoonnummer
+        </li>
+        <li>
+          <strong>tel-national</strong> - Telefoonnummer zonder de landcode, met
+          een binnenlands landspecifiek voorvoegsel indien van toepassing
+        </li>
+        <li>
+          <strong>tel-area-code</strong> - Netnummer van het telefoonnummer, met
+          een binnenlands landspecifiek voorvoegsel indien van toepassing
+        </li>
+        <li>
+          <strong>tel-local</strong> - Telefoonnummer zonder de landcode en het
+          netnummer
+        </li>
+        <li>
+          <strong>tel-local-prefix</strong> - Eerste deel van het gedeelte van
+          het telefoonnummer dat volgt op het netnummer wanneer dat gedeelte is
+          opgedeeld in twee delen
+        </li>
+        <li>
+          <strong>tel-local-suffix</strong> - Tweede deel van het gedeelte van
+          het telefoonnummer dat volgt op het netnummer wanneer dat gedeelte is
+          opgedeeld in twee delen
+        </li>
+        <li>
+          <strong>tel-extension</strong> - Intern toestelnummer behorende bij
+          een telefoonnummer
+        </li>
+        <li><strong>email</strong> - E-mailadres</li>
+        <li>
+          <strong>impp</strong> - URL die het eindpunt van een instant messaging
+          protocol vertegenwoordigt (bijvoorbeeld:
+          "<strong>aim:goim?screenname=example</strong>" of
+          "<strong>xmpp:fred@example.net</strong>")
+        </li>
+      </ul>
+    </section>
+
+
+    <section class="appendix" id="changelog"><div class="header-wrapper"><h2 id="a-change-log"><bdi class="secno">A. </bdi>Verander Log <a class="self-link" href="#changelog" aria-label="§"></a></h2></div>
+         		
+      <a class="self-link" href="#changelog" aria-label="Permalink for Appendix A."></a>
+         		
+      <p>Deze paragraaf toont de inhoudelijke wijzigingen van WCAG 2.2 sinds WCAG 2.1. <a href="https://www.w3.org/WAI/WCAG21/errata/">De errata-aanpassingen van WCAG 2.1</a> zijn ook verwerkt in WCAG 2.2. 
+
+        De volledige commitgeschiedenis van WCAG 2.2 is beschikbaar. 
+      </p>
+          
+        
+   </section>
+
+    <section class="appendix" id="dankbetuigingen">
+      <h2 id="a-dankbetuigingen">
+        <bdi class="secno">B. </bdi>Dankbetuigingen<a class="self-link" aria-label="§" href="#dankbetuigingen"></a>
+      </h2>
+      <p>
+        Aanvullende informatie over deelname aan de Accessibility Guidelines
+        Werkgroep (<abbr title="Accessibility Guidelines Working Group">AG WG</abbr>) is te vinden op de
+        <a href="https://www.w3.org/WAI/GL/">homepage van de Werkgroep</a>.
+      </p>
+
+      <section id="dankbetuiging-voor-actieve-deelnemers">
+        <h3 id="a-1-deelnemers-van-de-ag-wg-die-actief-zijn-bij-de-ontwikkeling-van-dit-document">
+          <bdi class="secno">B.1 </bdi> Deelnemers van de
+          <abbr title="Accessibility Guidelines Working Group">AG WG</abbr> die
+          actief zijn bij de ontwikkeling van dit document:
+          <a class="self-link" aria-label="§" href="#dankbetuiging-voor-actieve-deelnemers"></a>
+        </h3>
+        <ul>
+          <li>Jake Abma (Invited Expert)</li>
+          <li>
+            Shadi Abou-Zahra (<abbr title="World Wide Web Consortium">W3C</abbr>)
+          </li>
+          <li>Chuck Adams (Oracle Corporation)</li>
+          <li>Amani Ali (Nomensa)</li>
+          <li>Jim Allan (Invited Expert)</li>
+          <li>Paul Adam (Deque Systems, Inc.)</li>
+          <li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
+          <li>Jon Avila (Level Access)</li>
+          <li>Tom Babinszki (IBM Corporation)</li>
+          <li>Bruce Bailey (U.S. Access Board)</li>
+          <li>Renaldo Bernard (University of Southampton)</li>
+          <li>Chris Blouch (Level Access)</li>
+          <li>Denis Boudreau (Deque Systems, Inc.)</li>
+          <li>
+            Judy Brewer (<abbr title="World Wide Web Consortium">W3C</abbr>)
+          </li>
+          <li>Shari Butler (Pearson plc)</li>
+          <li>Thaddeus Cambron (Invited Expert)</li>
+          <li>Alastair Campbell (Nomensa)</li>
+          <li>Laura Carlson (Invited Expert)</li>
+          <li>Louis Cheng (Google)</li>
+          <li>Pietro Cirrincione (Invited Expert)</li>
+          <li>Vivienne Conway (Web Key IT Pty Ltd)</li>
+          <li>
+            Michael Cooper (<abbr title="World Wide Web Consortium">W3C</abbr>)
+          </li>
+          <li>Romain Deltour (DAISY Consortium)</li>
+          <li>Wayne Dick (Knowbility, Inc)</li>
+          <li>Chaohai Ding (University of Southampton)</li>
+          <li>Kim Dirks (Thompson Reuters)</li>
+          <li>Shwetank Dixit (BarrierBreak Technologies)</li>
+          <li>Anthony Doran (TextHelp)</li>
+          <li>E.A. Draffan (University of Southampton)</li>
+          <li>
+            Eric Eggert (<abbr title="World Wide Web Consortium">W3C</abbr>)
+          </li>
+          <li>Michael Elledge (Invited Expert)</li>
+          <li>Wilco Fiers (Deque Systems, Inc.)</li>
+          <li>Detlev Fischer (Invited Expert)</li>
+          <li>John Foliot (Deque Systems, Inc.)</li>
+          <li>Matt Garrish (DAISY Consortium)</li>
+          <li>Alistair Garrison (Level Access)</li>
+          <li>Michael Gower (IBM Corporation)</li>
+          <li>Jon Gunderson</li>
+          <li>Markku Hakkinen (Educational Testing Service)</li>
+          <li>Katie Haritos-Shea (Knowbility, Inc)</li>
+          <li>Andy Heath (Invited Expert)</li>
+          <li>
+            Shawn Henry (<abbr title="World Wide Web Consortium">W3C</abbr>)
+          </li>
+          <li>Thomas Hoffman (Educational Testing Service)</li>
+          <li>Sarah Horton (The Paciello Group, LLC)</li>
+          <li>Stefan Johansson (Invited Expert)</li>
+          <li>Marc Johlic (IBM Corporation)</li>
+          <li>Rick Johnson (VitalSource | Ingram Content Group)</li>
+          <li>Crystal Jones (Microsoft Corporation)</li>
+          <li>Andrew Kirkpatrick (Adobe)</li>
+          <li>John Kirkwood (Invited Expert)</li>
+          <li>
+            Jason Kiss (Department of Internal Affairs, New Zealand Government)
+          </li>
+          <li>Maureen Kraft (IBM Corporation)</li>
+          <li>JaEun Ku (University of Illinois at Urbana-Champaign)</li>
+          <li>Patrick Lauke (The Paciello Group, LLC)</li>
+          <li>Shawn Lauriat (Google, Inc.)</li>
+          <li>Steve Lee (Invited Expert)</li>
+          <li>Alex Li (Microsoft Corporation)</li>
+          <li>Chris Loiselle (Invited Expert)</li>
+          <li>Greg Lowney (Invited Expert)</li>
+          <li>Adam Lund (Thomson Reuters)</li>
+          <li>David MacDonald (Invited Expert)</li>
+          <li>Erich Manser (IBM Corporation)</li>
+          <li>Kurt Mattes (Deque Systems, Inc.)</li>
+          <li>Scott McCormack (Level Access)</li>
+          <li>Chris McMeeking (Deque Systems, Inc.)</li>
+          <li>Jan McSorley (Pearson plc)</li>
+          <li>Neil Milliken (Unify Software and Solutions)</li>
+          <li>Rachael Montgomery (MITRE Corporation)</li>
+          <li>Mary Jo Mueller (IBM Corporation)</li>
+          <li>Brooks Newton (Thomson Reuters)</li>
+          <li>James Nurthen (Oracle Corporation)</li>
+          <li>Joshue O Connor (Invited Expert)</li>
+          <li>Sailesh Panchang (Deque Systems, Inc.)</li>
+          <li>Charu Pandhi (IBM Corporation)</li>
+          <li>Kim Patch (Invited Expert)</li>
+          <li>Melanie Philipp (Deque Systems, Inc.)</li>
+          <li>Mike Pluke (Invited Expert)</li>
+          <li>Ian Pouncey (The Paciello Group, LLC)</li>
+          <li>
+            Ruoxi Ran (<abbr title="World Wide Web Consortium">W3C</abbr>)
+          </li>
+          <li>Stephen Repsher (The Boeing Company)</li>
+          <li>Jan Richards (Invited Expert)</li>
+          <li>John Rochford (Invited Expert)</li>
+          <li>Marla Runyan (Invited Expert)</li>
+          <li>Stefan Schnabel (SAP SE)</li>
+          <li>Ayelet Seeman (Invited Expert)</li>
+          <li>Lisa Seeman-Kestenbaum (Invited Expert)</li>
+          <li>Glenda Sims (Deque Systems, Inc.)</li>
+          <li>Avneesh Singh (DAISY Consortium)</li>
+          <li>David Sloan (The Paciello Group, LLC)</li>
+          <li>Alan Smith (Invited Expert)</li>
+          <li>Jim Smith (Unify Software and Solutions)</li>
+          <li>Adam Solomon (Invited Expert)</li>
+          <li>Jaeil Song (National Information Society Agency (NIA))</li>
+          <li>Jeanne Spellman (The Paciello Group, LLC)</li>
+          <li>Makoto Ueki (Invited Expert)</li>
+          <li>Jatin Vaishnav (Deque Systems, Inc.)</li>
+          <li>Gregg Vanderheiden (Raising the Floor)</li>
+          <li>Evangelos Vlachogiannis (Fraunhofer Gesellschaft)</li>
+          <li>Kathleen Wahlbin (Invited Expert)</li>
+          <li>Can Wang (Zhejiang University)</li>
+          <li>Léonie Watson (The Paciello Group, LLC)</li>
+          <li>Jason White (Educational Testing Service)</li>
+          <li>Mark Wilcock (Unify Software and Solutions)</li>
+        </ul>
+      </section>
+
+      <section id="dankbetuiging-voor-eerder-actieve-deelnemers">
+        <h3 id="a-2-andere-eerder-actieve-wcag-wg-deelnemers-en-andere-bijdragers-aan-wcag-2-0-wcag-2-1-of-ondersteunende-bronnen">
+          <bdi class="secno">B.2 </bdi>
+          Andere eerder actieve WCAG WG-deelnemers en andere bijdragers aan WCAG
+          2.0, WCAG 2.1 of ondersteunende bronnen
+          <a class="self-link" aria-label="§" href="#dankbetuiging-voor-eerder-actieve-deelnemers"></a>
+        </h3>
+        <p>
+          Paul Adam, Jenae Andershonis, Wilhelm Joys Andersen, Andrew Arch, Avi
+          Arditti, Aries Arditi, Mark Barratt, Mike Barta, Sandy Bartell, Kynn
+          Bartlett, Chris Beer, Charles Belov, Marco Bertoni, Harvey Bingham,
+          Chris Blouch, Paul Bohman, Frederick Boland, Denis Boudreau, Patrice
+          Bourlon, Andy Brown, Dick Brown, Doyle Burnett, Raven Calais, Ben
+          Caldwell, Tomas Caspers, Roberto Castaldo, Sofia Celic-Li, Sambhavi
+          Chandrashekar, Mike Cherim, Jonathan Chetwynd, Wendy Chisholm, Alan
+          Chuter, David M Clark, Joe Clark, Darcy Clarke, James Coltham, Earl
+          Cousins, James Craig, Tom Croucher, Pierce Crowell, Nir Dagan, Daniel
+          Dardailler, Geoff Deering, Sébastien Delorme, Pete DeVasto, Iyad Abu
+          Doush, Sylvie Duchateau, Cherie Eckholm, Roberto Ellero, Don Evans,
+          Gavin Evans, Neal Ewers, Steve Faulkner, Bengt Farre, Lainey Feingold,
+          Wilco Fiers, Michel Fitos, Alan J. Flavell, Nikolaos Floratos,
+          Kentarou Fukuda, Miguel Garcia, P.J. Gardner, Alistair Garrison, Greg
+          Gay, Becky Gibson, Al Gilman, Kerstin Goldsmith, Michael Grade, Karl
+          Groves, Loretta Guarino Reid, Jon Gunderson, Emmanuelle Gutiérrez y
+          Restrepo, Brian Hardy, Eric Hansen, Benjamin Hawkes-Lewis, Sean Hayes,
+          Shawn Henry, Hans Hillen, Donovan Hipke, Bjoern Hoehrmann, Allen
+          Hoffman, Chris Hofstader, Yvette Hoitink, Martijn Houtepen, Carlos
+          Iglesias, Richard Ishida, Jonas Jacek, Ian Jacobs, Phill Jenkins,
+          Barry Johnson, Duff Johnson, Jyotsna Kaki, Shilpi Kapoor, Leonard R.
+          Kasday, Kazuhito Kidachi, Ken Kipness, Johannes Koch, Marja-Riitta
+          Koivunen, Preety Kumar, Kristjan Kure, Andrew LaHart, Gez Lemon, Chuck
+          Letourneau, Aurélien Levy, Harry Loots, Scott Luebking, Tim Lacy, Jim
+          Ley, Alex Li, William Loughborough, N Maffeo, Mark Magennis, Kapsi
+          Maria, Luca Mascaro, Matt May, Sheena McCullagh, Liam McGee, Jens
+          Oliver Meiert, Niqui Merret, Jonathan Metz, Alessandro Miele, Steven
+          Miller, Mathew J Mirabella, Matt May, Marti McCuller, Sorcha Moore,
+          Charles F. Munat, Robert Neff, Charles Nevile, Liddy Nevile, Dylan
+          Nicholson, Bruno von Niman, Tim Noonan, Sebastiano Nutarelli, Graham
+          Oliver, Sean B. Palmer, Devarshi Pant, Nigel Peck, Anne Pemberton,
+          David Poehlman, Ian Pouncey, Charles Pritchard, Kerstin Probiesch, W
+          Reagan, Adam Victor Reed, Chris Reeve, Chris Ridpath, Lee Roberts,
+          Mark Rogers, Raph de Rooij, Gregory J. Rosmaita, Matthew Ross, Sharron
+          Rush, Joel Sanda, Janina Sajka, Roberto Scano, Gordon Schantz, Tim van
+          Schie, Wolf Schmidt, Stefan Schnabel, Cynthia Shelly, Glenda Sims,
+          John Slatin, Becky Smith, Jared Smith, Andi Snow-Weaver, Neil Soiffer,
+          Mike Squillace, Michael Stenitzer, Diane Stottlemyer, Christophe
+          Strobbe, Sarah J Swierenga, Jim Thatcher, Terry Thompson, Justin
+          Thorp, David Todd, Mary Utt, Jean Vanderdonckt, Carlos A Velasco, Eric
+          Velleman, Gijs Veyfeyken, Dena Wainwright, Paul Walsch, Daman Wandke,
+          Richard Warren, Elle Waters, Takayuki Watanabe, Gian Wild, David
+          Wooley, Wu Wei, Kenny Zhang, Leona Zumbo.
+        </p>
+      </section>
+
+      <section id="mede-mogelijk-gemaakt-door">
+        <h3 id="a-3-mede-mogelijk-gemaakt-door">
+          <bdi class="secno">B.3 </bdi>Mede mogelijk gemaakt door:<a class="self-link" aria-label="§" href="#mede-mogelijk-gemaakt-door"></a>
+        </h3>
+        <p>
+          Deze publicatie is gedeeltelijk gefinancierd met Amerikaanse federale
+          fondsen van het
+          <span lang="en">Health and Human Services, National Institute on Disability,
+            Independent Living and Rehabilitation Research</span>
+          (NIDILRR), aanvankelijk onder contractnummer ED-OSE-10-C-0067, daarna onder HHSP23301500054C en nu onder HHS75P00120P00168. De inhoud van deze publicatie
+          geeft niet noodzakelijk de opvattingen of het beleid van het
+          Amerikaanse ministerie van Volksgezondheid en Human Services of het
+          Amerikaanse ministerie van Onderwijs weer, noch impliceert vermelding
+          van handelsnamen, commerciële producten of organisaties goedkeuring
+          door de Amerikaanse overheid.
+        </p>
+      </section>
+    </section>
+
+    <section id="referenties" class="appendix">
+      <h2 id="b-referenties">
+        <bdi class="secno">C. </bdi>Referenties<a class="self-link" aria-label="§" href="#referenties"></a>
+      </h2>
+
+
+      <section id="informative-references"><div class="header-wrapper"><h3 id="c-1-informative-references"><bdi class="secno">C.1 </bdi>Informatieve referenties</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix C.1"></a></div>
+    
+        <dl class="bibliography"><dt id="bib-css3-values">[css3-values]</dt><dd>
+          <a href="https://www.w3.org/TR/css-values-3/"><cite>CSS Values and Units Module Level 3</cite></a>. Tab Atkins Jr.; Elika Etemad.  W3C. 1 December 2022. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
+        </dd><dt id="bib-html">[HTML]</dt><dd>
+          <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+        </dd><dt id="bib-iso_9241-391">[ISO_9241-391]</dt><dd>
+          <a href="https://www.iso.org/standard/56350.html"><cite>Ergonomics of human-system interaction—Part 391: Requirements, analysis and compliance test methods for the reduction of photosensitive seizures</cite></a>.  International Standards Organization. URL: <a href="https://www.iso.org/standard/56350.html">https://www.iso.org/standard/56350.html</a>
+        </dd><dt id="bib-pointerevents">[pointerevents]</dt><dd>
+          <a href="https://www.w3.org/TR/pointerevents/"><cite>Pointer Events</cite></a>. Jacob Rossi; Matt Brubeck.  W3C. 4 April 2019. W3C Recommendation. URL: <a href="https://www.w3.org/TR/pointerevents/">https://www.w3.org/TR/pointerevents/</a>
+        </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+          <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+        </dd><dt id="bib-srgb">[SRGB]</dt><dd>
+          <a href="https://webstore.iec.ch/publication/6169"><cite>Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB</cite></a>.  IEC. URL: <a href="https://webstore.iec.ch/publication/6169">https://webstore.iec.ch/publication/6169</a>
+        </dd><dt id="bib-uaag10">[UAAG10]</dt><dd>
+          <a href="https://www.w3.org/TR/UAAG10/"><cite>User Agent Accessibility Guidelines 1.0</cite></a>. Ian Jacobs; Jon Gunderson; Eric Hansen.  W3C. 17 December 2002. W3C Recommendation. URL: <a href="https://www.w3.org/TR/UAAG10/">https://www.w3.org/TR/UAAG10/</a>
+        </dd><dt id="bib-unesco">[UNESCO]</dt><dd>
+          <a href="https://unesdoc.unesco.org/ark:/48223/pf0000219109"><cite>International Standard Classification of Education</cite></a>. 2011. URL: <a href="https://unesdoc.unesco.org/ark:/48223/pf0000219109">https://unesdoc.unesco.org/ark:/48223/pf0000219109</a>
+        </dd><dt id="bib-wai-webcontent">[WAI-WEBCONTENT]</dt><dd>
+          <a href="https://www.w3.org/TR/WAI-WEBCONTENT/"><cite>Web Content Accessibility Guidelines 1.0</cite></a>. Wendy Chisholm; Gregg Vanderheiden; Ian Jacobs.  W3C. 5 May 1999. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WAI-WEBCONTENT/">https://www.w3.org/TR/WAI-WEBCONTENT/</a>
+        </dd><dt id="bib-wcag20">[WCAG20]</dt><dd>
+          <a href="https://www.w3.org/TR/WCAG20/"><cite>Web Content Accessibility Guidelines (WCAG) 2.0</cite></a>. Ben Caldwell; Michael Cooper; Loretta Guarino Reid; Gregg Vanderheiden et al.  W3C. 11 December 2008. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WCAG20/">https://www.w3.org/TR/WCAG20/</a>
+        </dd><dt id="bib-wcag21">[WCAG21]</dt><dd>
+          <a href="https://www.w3.org/TR/WCAG21/"><cite>Web Content Accessibility Guidelines (WCAG) 2.1</cite></a>. Michael Cooper; Andrew Kirkpatrick; Joshue O'Connor; Alastair Campbell.  W3C. 21 September 2023. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>
+        </dd></dl>
+      </section>
+      <section id="normatieve-referenties">
+        <h3 id="b-1-normatieve-referenties">
+          <bdi class="secno">C.1 </bdi>Normatieve referenties<a class="self-link" aria-label="§" href="#normatieve-referenties"></a>
+        </h3>
+        <dl class="bibliography">
+          <dt id="bib-css3-values">[css3-values]</dt>
+          <dd>
+            <a href="https://www.w3.org/TR/css-values-3/">
+              <cite>CSS Values and Units Module Level 3</cite> </a>. Tab Atkins Jr.; Elika Etemad.
+            <abbr title="World Wide Web Consortium">W3C</abbr>. 29 September
+            2016. <abbr title="World Wide Web Consortium">W3C</abbr> Candidate
+            Recommendation. URL:
+            <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
+          </dd>
+          <dt id="bib-pointerevents">[pointerevents]</dt>
+          <dd>
+            <a href="https://www.w3.org/TR/pointerevents/">
+              <cite>Pointer Events</cite> </a>. Jacob Rossi; Matt Brubeck.
+            <abbr title="World Wide Web Consortium">W3C</abbr>. 24 February
+            2015.
+            <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+            URL:
+            <a href="https://www.w3.org/TR/pointerevents/">https://www.w3.org/TR/pointerevents/</a>
+          </dd>
+          <dt id="bib-wcag20">[WCAG20]</dt>
+          <dd>
+            <a href="https://www.w3.org/TR/WCAG20/">
+              <cite>Web Content Accessibility Guidelines (WCAG) 2.0</cite> </a>. Ben Caldwell; Michael Cooper; Loretta Guarino Reid; Gregg
+            Vanderheiden et al.
+            <abbr title="World Wide Web Consortium">W3C</abbr>. 11 December
+            2008.
+            <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+            URL:
+            <a href="https://www.w3.org/TR/WCAG20/">https://www.w3.org/TR/WCAG20/</a>
+          </dd>
+        </dl>
+      </section>
+    </section>
+
+    <p role="navigation" id="back-to-top">
+      <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+    </p>
+    <script>
+      /******************************************************************************
+       * NB: THIS IS A MODIFICATION OF:                                             *
+       * JS Extension for the W3C Spec Style Sheet                                  *
+       *                                                                            *
+       * This code handles:                                                         *
+       * - some fixup to improve the table of contents                              *
+       * - the obsolete warning on outdated specs                                   *
+       *
+       * MODIFICATIONS:
+       * - Translated linkcontent to Dutch (nl-NL)
+       ******************************************************************************/
+      (function() {
+        'use strict';
+
+        var ESCAPEKEY = 27;
+        var collapseSidebarText =
+          '<span aria-hidden="true">←</span> ' + '<span>Zijbalk inklappen</span>';
+        var expandSidebarText =
+          '<span aria-hidden="true">→</span> ' + '<span>Zijbalk uitklappen</span>';
+        var tocJumpText =
+          '<span aria-hidden="true">↑</span> ' + '<span>Naar de inhoudsopgave</span>';
+
+        var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
+        var autoToggle = function(e) {
+          toggleSidebar(e.matches);
+        };
+        if (sidebarMedia.addListener) {
+          sidebarMedia.addListener(autoToggle);
+        }
+
+        function toggleSidebar(on, skipScroll) {
+          if (on == undefined) {
+            on = !document.body.classList.contains('toc-sidebar');
+          }
+
+          if (!skipScroll) {
+            /* Don't scroll to compensate for the ToC if we're above it already. */
+            var headY = 0;
+            var head = document.querySelector('.head');
+            if (head) {
+              // terrible approx of "top of ToC"
+              headY += head.offsetTop + head.offsetHeight;
+            }
+            skipScroll = window.scrollY < headY;
+          }
+
+          var toggle = document.getElementById('toc-toggle');
+          var tocNav = document.getElementById('toc');
+          if (on) {
+            var tocHeight = tocNav.offsetHeight;
+
+            document.body.classList.add('toc-sidebar');
+            document.body.classList.remove('toc-inline');
+            toggle.innerHTML = collapseSidebarText;
+            if (!skipScroll) {
+              window.scrollBy(0, 0 - tocHeight);
+            }
+            tocNav.focus();
+            sidebarMedia.addListener(autoToggle); // auto-collapse when out of room
+          } else {
+            document.body.classList.add('toc-inline');
+            document.body.classList.remove('toc-sidebar');
+            toggle.innerHTML = expandSidebarText;
+            if (!skipScroll) {
+              window.scrollBy(0, tocNav.offsetHeight);
+            }
+            if (toggle.matches(':hover')) {
+              /* Unfocus button when not using keyboard navigation,
+                 because I don't know where else to send the focus. */
+              toggle.blur();
+            }
+          }
+        }
+
+        function createSidebarToggle() {
+          /* Create the sidebar toggle in JS; it shouldn't exist when JS is off. */
+          var toggle = document.createElement('a');
+          /* This should probably be a button, but appearance isn't standards-track. */
+          toggle.id = 'toc-toggle';
+          toggle.class = 'toc-toggle';
+          toggle.href = '#toc';
+          toggle.innerHTML = collapseSidebarText;
+
+          sidebarMedia.addListener(autoToggle);
+          var toggler = function(e) {
+            e.preventDefault();
+            sidebarMedia.removeListener(autoToggle); // persist explicit off states
+            toggleSidebar();
+            return false;
+          };
+          toggle.addEventListener('click', toggler, false);
+
+          /* Get <nav id=toc-nav>, or make it if we don't have one. */
+          var tocNav = document.getElementById('toc-nav');
+          if (!tocNav) {
+            tocNav = document.createElement('p');
+            tocNav.id = 'toc-nav';
+            /* Prepend for better keyboard navigation */
+            document.body.insertBefore(tocNav, document.body.firstChild);
+          }
+          /* While we're at it, make sure we have a Jump to Toc link. */
+          var tocJump = document.getElementById('toc-jump');
+          if (!tocJump) {
+            tocJump = document.createElement('a');
+            tocJump.id = 'toc-jump';
+            tocJump.href = '#toc';
+            tocJump.innerHTML = tocJumpText;
+            tocNav.appendChild(tocJump);
+          }
+
+          tocNav.appendChild(toggle);
+        }
+
+        var toc = document.getElementById('toc');
+        if (toc) {
+          if (!document.getElementById('toc-toggle')) {
+            createSidebarToggle();
+          }
+          toggleSidebar(sidebarMedia.matches, true);
+
+          /* If the sidebar has been manually opened and is currently overlaying the text
+             (window too small for the MQ to add the margin to body),
+             then auto-close the sidebar once you click on something in there. */
+          toc.addEventListener(
+            'click',
+            function(e) {
+              if (
+                document.body.classList.contains('toc-sidebar') &&
+                !sidebarMedia.matches
+              ) {
+                var el = e.target;
+                while (el != toc) {
+                  // find closest <a>
+                  if (el.tagName.toLowerCase() == 'a') {
+                    toggleSidebar(false);
+                    return;
+                  }
+                  el = el.parentElement;
+                }
+              }
+            },
+            false
+          );
+        } else {
+          console.warn(
+            'Can\'t find Table of Contents. Please use <nav id=\'toc\'> around the ToC.'
+          );
+        }
+
+        /* Wrap tables in case they overflow */
+        var tables = document.querySelectorAll(
+          ':not(.overlarge) > table.data, :not(.overlarge) > table.index'
+        );
+        var numTables = tables.length;
+        for (var i = 0; i < numTables; i++) {
+          var table = tables[i];
+          if (
+            !table.matches('.example *, .note *, .advisement *, .def *, .issue *')
+          ) {
+            /* Overflowing colored boxes looks terrible, and also
+               the kinds of tables inside these boxes
+               are less likely to need extra space. */
+            var wrapper = document.createElement('div');
+            wrapper.className = 'overlarge';
+            table.parentNode.insertBefore(wrapper, table);
+            wrapper.appendChild(table);
+          }
+        }
+
+        /* Deprecation warning */
+        if (
+          document.location.hostname === 'www.w3.org' &&
+          /^\/TR\/\d{4}\//.test(document.location.pathname)
+        ) {
+          var request = new XMLHttpRequest();
+
+          request.open('GET', 'https://www.w3.org/TR/tr-outdated-spec');
+          request.onload = function() {
+            if (request.status < 200 || request.status >= 400) {
+              return;
+            }
+            try {
+              var currentSpec = JSON.parse(request.responseText);
+            } catch (err) {
+              console.error(err);
+              return;
+            }
+            document.body.classList.add('outdated-spec');
+            var node = document.createElement('p');
+            node.classList.add('outdated-warning');
+            node.tabIndex = -1;
+            node.setAttribute('role', 'dialog');
+            node.setAttribute('aria-modal', 'true');
+            node.setAttribute('aria-labelledby', 'outdatedWarning');
+            if (currentSpec.style) {
+              node.classList.add(currentSpec.style);
+            }
+
+            var frag = document.createDocumentFragment();
+            var heading = document.createElement('strong');
+            heading.id = 'outdatedWarning';
+            heading.innerHTML = currentSpec.header;
+            frag.appendChild(heading);
+
+            var anchor = document.createElement('a');
+            anchor.id = 'outdated-note';
+            anchor.href = currentSpec.latestUrl;
+            anchor.innerText = currentSpec.latestUrl + '.';
+
+            var warning = document.createElement('span');
+            warning.innerText = currentSpec.warning;
+            warning.appendChild(anchor);
+            frag.appendChild(warning);
+
+            var button = document.createElement('button');
+            var handler = makeClickHandler(node);
+            button.addEventListener('click', handler);
+            button.innerHTML = '&#9662; collapse';
+            frag.appendChild(button);
+            node.appendChild(frag);
+
+            function makeClickHandler(node) {
+              var isOpen = true;
+              return function collapseWarning(event) {
+                var button = event.target;
+                isOpen = !isOpen;
+                node.classList.toggle('outdated-collapsed');
+                document.body.classList.toggle('outdated-spec');
+                button.innerText = isOpen ? '\u25BE collapse' : '\u25B4 expand';
+              };
+            }
+
+            document.body.appendChild(node);
+            button.focus();
+            window.onkeydown = function(event) {
+              var isCollapsed = node.classList.contains('outdated-collapsed');
+              if (event.keyCode === ESCAPEKEY && !isCollapsed) {
+                button.click();
+              }
+            };
+
+            document.addEventListener(
+              'focus',
+              function(event) {
+                var isCollapsed = node.classList.contains('outdated-collapsed');
+                var containsTarget = node.contains(event.target);
+                if (!isCollapsed && !containsTarget) {
+                  event.stopPropagation();
+                  node.focus();
+                }
+              },
+              true
+            ); // use capture to enable event delegation as focus doesn't bubble up
+          };
+
+          request.onerror = function() {
+            console.error(
+              'Request to https://www.w3.org/TR/tr-outdated-spec failed.'
+            );
+          };
+
+          request.send();
+        }
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
New version for the WCAG translated to Dutch. Can this be published?

In order to activate this new index.html it seems like the symlink here: https://github.com/AccessibilityNL/WCAG21-NL/blob/master/translations/WCAG21-nl/index.html needs to be updated to the new file, which is in the folder that is pushed in this PR